### PR TITLE
Feat: 유저 정보 조회/수정

### DIFF
--- a/src/main/kotlin/com/wafflestudio/team03server/common/ExceptionHandler.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/common/ExceptionHandler.kt
@@ -14,6 +14,12 @@ class ExceptionHandler {
 
     // Request Validation
     @ExceptionHandler(value = [MethodArgumentNotValidException::class])
-    fun handle(e: MethodArgumentNotValidException): ResponseEntity<Any> =
-        ResponseEntity(e.bindingResult.allErrors[0].defaultMessage, HttpStatus.BAD_REQUEST)
+    fun handle(e: MethodArgumentNotValidException): ResponseEntity<Any> {
+        val errors = mutableListOf<String>()
+        e.bindingResult.fieldErrors.forEach { fieldError ->
+            val errorMessage = fieldError.defaultMessage ?: "값이 유효하지 않습니다."
+            errors.add(errorMessage)
+        }
+        return ResponseEntity(errors, HttpStatus.BAD_REQUEST)
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/config/WebConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/config/WebConfig.kt
@@ -2,7 +2,6 @@ package com.wafflestudio.team03server.config
 
 import com.wafflestudio.team03server.common.Authenticated
 import com.wafflestudio.team03server.common.Exception401
-import com.wafflestudio.team03server.common.Exception403
 import com.wafflestudio.team03server.common.UserContext
 import com.wafflestudio.team03server.core.user.service.AuthTokenService
 import org.springframework.context.annotation.Configuration

--- a/src/main/kotlin/com/wafflestudio/team03server/config/WebConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/config/WebConfig.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.team03server.config
 
 import com.wafflestudio.team03server.common.Authenticated
+import com.wafflestudio.team03server.common.Exception401
 import com.wafflestudio.team03server.common.Exception403
 import com.wafflestudio.team03server.common.UserContext
 import com.wafflestudio.team03server.core.user.service.AuthTokenService
@@ -55,7 +56,7 @@ class AuthInterceptor(private val authTokenService: AuthTokenService) : HandlerI
         val handlerCasted = (handler as? HandlerMethod) ?: return true
         if (handlerCasted.hasMethodAnnotation(Authenticated::class.java)) {
             val accessToken =
-                request.getHeader("Authorization") ?: throw Exception403("Missing token for authorization")
+                request.getHeader("Authorization") ?: throw Exception401("로그인 후 이용하실 수 있습니다.")
             authTokenService.verifyToken(accessToken)
             request.setAttribute("userId", authTokenService.getCurrentUserId(accessToken))
         }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/AuthController.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/AuthController.kt
@@ -17,13 +17,13 @@ class AuthController(
     // 이메일 중복체크
     @GetMapping("/checkEmail")
     fun checkEmail(@RequestParam("email") email: String): ResponseEntity<Boolean> {
-        return ResponseEntity(authService.checkDuplicatedEmail(email), HttpStatus.OK)
+        return ResponseEntity(!authService.isDuplicateEmail(email), HttpStatus.OK)
     }
 
     // 유저네임 중복체크
     @GetMapping("/checkUsername")
     fun checkUsername(@RequestParam("username") username: String): ResponseEntity<Boolean> {
-        return ResponseEntity(authService.checkDuplicateUsername(username), HttpStatus.OK)
+        return ResponseEntity(!authService.isDuplicateUsername(username), HttpStatus.OK)
     }
 
     // 회원가입

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/AuthController.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/AuthController.kt
@@ -59,7 +59,7 @@ class AuthController(
     // 로그인
     @PostMapping("/login")
     fun login(@RequestBody @Valid loginRequest: LoginRequest): ResponseEntity<LoginResponse> {
-        val response = authService.login(loginRequest.email!!, loginRequest.password!!)
+        val response = authService.login(loginRequest.email, loginRequest.password)
         return ResponseEntity(response, HttpStatus.OK)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/UserController.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/UserController.kt
@@ -1,5 +1,7 @@
 package com.wafflestudio.team03server.core.user.api
 
+import com.wafflestudio.team03server.common.Authenticated
+import com.wafflestudio.team03server.common.UserContext
 import com.wafflestudio.team03server.core.user.api.response.UserResponse
 import com.wafflestudio.team03server.core.user.service.UserService
 import org.springframework.http.HttpStatus
@@ -17,6 +19,12 @@ class UserController(
 
     @GetMapping("/{user-id}")
     fun getUser(@PathVariable("user-id") userId: Long): ResponseEntity<UserResponse> {
+        return ResponseEntity(userService.getUser(userId),HttpStatus.OK)
+    }
+
+    @Authenticated
+    @GetMapping("/me")
+    fun getMe(@UserContext userId: Long): ResponseEntity<UserResponse>{
         return ResponseEntity(userService.getUser(userId),HttpStatus.OK)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/UserController.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/UserController.kt
@@ -2,14 +2,14 @@ package com.wafflestudio.team03server.core.user.api
 
 import com.wafflestudio.team03server.common.Authenticated
 import com.wafflestudio.team03server.common.UserContext
+import com.wafflestudio.team03server.core.user.api.request.EditPasswordRequest
+import com.wafflestudio.team03server.core.user.api.request.EditProfileRequest
 import com.wafflestudio.team03server.core.user.api.response.UserResponse
 import com.wafflestudio.team03server.core.user.service.UserService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
+import javax.validation.Valid
 
 @RestController
 @RequestMapping("/users")
@@ -19,12 +19,25 @@ class UserController(
 
     @GetMapping("/{user-id}")
     fun getUser(@PathVariable("user-id") userId: Long): ResponseEntity<UserResponse> {
-        return ResponseEntity(userService.getUser(userId),HttpStatus.OK)
+        return ResponseEntity(userService.getProfile(userId),HttpStatus.OK)
     }
 
     @Authenticated
     @GetMapping("/me")
     fun getMe(@UserContext userId: Long): ResponseEntity<UserResponse>{
-        return ResponseEntity(userService.getUser(userId),HttpStatus.OK)
+        return ResponseEntity(userService.getProfile(userId),HttpStatus.OK)
+    }
+
+    @Authenticated
+    @PatchMapping("/me")
+    fun editMe(@UserContext userId: Long, @Valid @RequestBody editProfileRequest: EditProfileRequest): ResponseEntity<UserResponse>{
+        return ResponseEntity(userService.editProfile(userId,editProfileRequest),HttpStatus.OK)
+    }
+
+    @Authenticated
+    @PutMapping("/me/password")
+    fun editPassword(@UserContext userId:Long,@Valid @RequestBody editPasswordRequest: EditPasswordRequest ):ResponseEntity<Any>{
+        userService.editPassword(userId,editPasswordRequest)
+        return ResponseEntity(HttpStatus.OK)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/UserController.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/UserController.kt
@@ -19,25 +19,25 @@ class UserController(
 
     @GetMapping("/{user-id}")
     fun getUser(@PathVariable("user-id") userId: Long): ResponseEntity<UserResponse> {
-        return ResponseEntity(userService.getProfile(userId),HttpStatus.OK)
+        return ResponseEntity(userService.getProfile(userId), HttpStatus.OK)
     }
 
     @Authenticated
     @GetMapping("/me")
-    fun getMe(@UserContext userId: Long): ResponseEntity<UserResponse>{
-        return ResponseEntity(userService.getProfile(userId),HttpStatus.OK)
+    fun getMe(@UserContext userId: Long): ResponseEntity<UserResponse> {
+        return ResponseEntity(userService.getProfile(userId), HttpStatus.OK)
     }
 
     @Authenticated
     @PatchMapping("/me")
-    fun editMe(@UserContext userId: Long, @Valid @RequestBody editProfileRequest: EditProfileRequest): ResponseEntity<UserResponse>{
-        return ResponseEntity(userService.editProfile(userId,editProfileRequest),HttpStatus.OK)
+    fun editMe(@UserContext userId: Long, @Valid @RequestBody editProfileRequest: EditProfileRequest): ResponseEntity<UserResponse> {
+        return ResponseEntity(userService.editProfile(userId, editProfileRequest), HttpStatus.OK)
     }
 
     @Authenticated
     @PutMapping("/me/password")
-    fun editPassword(@UserContext userId:Long,@Valid @RequestBody editPasswordRequest: EditPasswordRequest ):ResponseEntity<Any>{
-        userService.editPassword(userId,editPasswordRequest)
+    fun editPassword(@UserContext userId: Long, @Valid @RequestBody editPasswordRequest: EditPasswordRequest): ResponseEntity<Any> {
+        userService.editPassword(userId, editPasswordRequest)
         return ResponseEntity(HttpStatus.OK)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/UserController.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/UserController.kt
@@ -30,13 +30,19 @@ class UserController(
 
     @Authenticated
     @PatchMapping("/me")
-    fun editMe(@UserContext userId: Long, @Valid @RequestBody editProfileRequest: EditProfileRequest): ResponseEntity<UserResponse> {
+    fun editMe(
+        @UserContext userId: Long,
+        @Valid @RequestBody editProfileRequest: EditProfileRequest
+    ): ResponseEntity<UserResponse> {
         return ResponseEntity(userService.editProfile(userId, editProfileRequest), HttpStatus.OK)
     }
 
     @Authenticated
     @PutMapping("/me/password")
-    fun editPassword(@UserContext userId: Long, @Valid @RequestBody editPasswordRequest: EditPasswordRequest): ResponseEntity<Any> {
+    fun editPassword(
+        @UserContext userId: Long,
+        @Valid @RequestBody editPasswordRequest: EditPasswordRequest
+    ): ResponseEntity<Any> {
         userService.editPassword(userId, editPasswordRequest)
         return ResponseEntity(HttpStatus.OK)
     }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/UserController.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/UserController.kt
@@ -1,13 +1,22 @@
 package com.wafflestudio.team03server.core.user.api
 
+import com.wafflestudio.team03server.core.user.api.response.UserResponse
+import com.wafflestudio.team03server.core.user.service.UserService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-class UserController {
+@RequestMapping("/users")
+class UserController(
+    private val userService: UserService
+) {
 
-    @GetMapping("/hello")
-    fun hello(): String {
-        return "hello"
+    @GetMapping("/{user-id}")
+    fun getUser(@PathVariable("user-id") userId: Long): ResponseEntity<UserResponse> {
+        return ResponseEntity(userService.getUser(userId),HttpStatus.OK)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/EditPasswordRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/EditPasswordRequest.kt
@@ -1,0 +1,10 @@
+package com.wafflestudio.team03server.core.user.api.request
+
+import javax.validation.constraints.NotBlank
+
+data class EditPasswordRequest(
+    val password:String,
+    @field:NotBlank(message = "비밀번호는 필수 항목입니다.")
+    val newPassword:String?,
+    val newPasswordConfirm:String
+)

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/EditPasswordRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/EditPasswordRequest.kt
@@ -1,12 +1,13 @@
 package com.wafflestudio.team03server.core.user.api.request
 
-import javax.validation.constraints.NotBlank
 import javax.validation.constraints.Pattern
 
 data class EditPasswordRequest(
-    val password:String,
-    @field:Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@\$!%*#?&])[A-Za-z\\d@\$!%*#?&]{8,15}\$",
-        message = "비밀번호는 특수문자, 영문자, 숫자 포함 8~15자 여야 합니다")
-    val newPassword:String?,
-    val newPasswordConfirm:String
+    val password: String,
+    @field:Pattern(
+        regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@\$!%*#?&])[A-Za-z\\d@\$!%*#?&]{8,15}\$",
+        message = "비밀번호는 특수문자, 영문자, 숫자 포함 8~15자 여야 합니다"
+    )
+    val newPassword: String?,
+    val newPasswordConfirm: String
 )

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/EditPasswordRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/EditPasswordRequest.kt
@@ -1,10 +1,12 @@
 package com.wafflestudio.team03server.core.user.api.request
 
 import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Pattern
 
 data class EditPasswordRequest(
     val password:String,
-    @field:NotBlank(message = "비밀번호는 필수 항목입니다.")
+    @field:Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@\$!%*#?&])[A-Za-z\\d@\$!%*#?&]{8,15}\$",
+        message = "비밀번호는 특수문자, 영문자, 숫자 포함 8~15자 여야 합니다")
     val newPassword:String?,
     val newPasswordConfirm:String
 )

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/EditProfileRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/EditProfileRequest.kt
@@ -1,9 +1,11 @@
 package com.wafflestudio.team03server.core.user.api.request
 
 import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Pattern
 
 data class EditProfileRequest(
-    @field:NotBlank(message = "유저네임은 필수 항목입니다.")
+    @field:Pattern(regexp = "^[\\p{L}\\p{Nd}가-힣]{1,10}\$",
+        message = "유저네임은 영문자, 숫자, 한글 중 하나 이상을 포함해야 하며, 1~10자 여야 합니다.")
     val username:String?,
     @field:NotBlank(message = "주소는 필수 항목입니다.")
     val location:String?,

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/EditProfileRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/EditProfileRequest.kt
@@ -1,0 +1,12 @@
+package com.wafflestudio.team03server.core.user.api.request
+
+import javax.validation.constraints.NotBlank
+
+data class EditProfileRequest(
+    @field:NotBlank(message = "유저네임은 필수 항목입니다.")
+    val username:String?,
+    @field:NotBlank(message = "주소는 필수 항목입니다.")
+    val location:String?,
+    @field:NotBlank(message = "프로필 이미지 주소는 필수 항목입니다.")
+    val imgUrl:String?
+)

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/EditProfileRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/EditProfileRequest.kt
@@ -4,11 +4,13 @@ import javax.validation.constraints.NotBlank
 import javax.validation.constraints.Pattern
 
 data class EditProfileRequest(
-    @field:Pattern(regexp = "^[\\p{L}\\p{Nd}가-힣]{1,10}\$",
-        message = "유저네임은 영문자, 숫자, 한글 중 하나 이상을 포함해야 하며, 1~10자 여야 합니다.")
-    val username:String?,
+    @field:Pattern(
+        regexp = "^[\\p{L}\\p{Nd}가-힣]{1,10}\$",
+        message = "유저네임은 영문자, 숫자, 한글 중 하나 이상을 포함해야 하며, 1~10자 여야 합니다."
+    )
+    val username: String?,
     @field:NotBlank(message = "주소는 필수 항목입니다.")
-    val location:String?,
+    val location: String?,
     @field:NotBlank(message = "프로필 이미지 주소는 필수 항목입니다.")
-    val imgUrl:String?
+    val imgUrl: String?
 )

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/GoogleLoginRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/GoogleLoginRequest.kt
@@ -4,7 +4,5 @@ import javax.validation.constraints.Email
 import javax.validation.constraints.NotBlank
 
 data class GoogleLoginRequest(
-    @field:Email(message = "Invalid email")
-    @field:NotBlank(message = "email is required")
     val email: String,
 )

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/GoogleLoginRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/GoogleLoginRequest.kt
@@ -1,8 +1,5 @@
 package com.wafflestudio.team03server.core.user.api.request
 
-import javax.validation.constraints.Email
-import javax.validation.constraints.NotBlank
-
 data class GoogleLoginRequest(
     val email: String,
 )

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/LoginRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/LoginRequest.kt
@@ -3,8 +3,6 @@ package com.wafflestudio.team03server.core.user.api.request
 import javax.validation.constraints.NotBlank
 
 data class LoginRequest(
-    @field:NotBlank(message = "email is required")
-    val email: String?,
-    @field:NotBlank(message = "password is required")
-    val password: String?
+    val email: String,
+    val password: String
 )

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/LoginRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/LoginRequest.kt
@@ -1,7 +1,5 @@
 package com.wafflestudio.team03server.core.user.api.request
 
-import javax.validation.constraints.NotBlank
-
 data class LoginRequest(
     val email: String,
     val password: String

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/SignUpRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/SignUpRequest.kt
@@ -8,15 +8,15 @@ import javax.validation.constraints.Pattern
 data class SignUpRequest(
     @field:Pattern(
         regexp = "^([a-zA-Z0-9가-힣]){2,10}\$",
-        message = "유저네임은 영문자, 숫자, 한글 중 하나 이상을 포함해야 하며, 1~10자 여야 합니다."
+        message = "유저네임은 영문자, 숫자, 한글 중 하나 이상을 포함해야 하며, 2~10자 여야 합니다."
     )
     val username: String?,
     @field:Email(message = "이메일 형식이 올바르지 않습니다.")
     @field:NotBlank(message = "이메일은 필수 항목입니다.")
     val email: String?,
     @field:Pattern(
-        regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@\$!%*#?&])[A-Za-z\\d@\$!%*#?&]{8,15}\$",
-        message = "비밀번호는 특수문자, 영문자, 숫자 포함 8~15자 여야 합니다"
+        regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@\$!%*#?&])[A-Za-z\\d@\$!%*#?&]{8,20}\$",
+        message = "비밀번호는 특수문자, 영문자, 숫자 포함 8~20자 여야 합니다"
     )
     val password: String?,
     @field:NotBlank(message = "주소는 필수 항목입니다.")

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/SignUpRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/SignUpRequest.kt
@@ -5,14 +5,14 @@ import javax.validation.constraints.Email
 import javax.validation.constraints.NotBlank
 
 data class SignUpRequest(
-    @field:NotBlank(message = "username is required")
+    @field:NotBlank(message = "유저네임은 필수 항목입니다.")
     val username: String?,
-    @field:Email(message = "Invalid email")
-    @field:NotBlank(message = "email is required")
+    @field:Email(message = "이메일 형식이 올바르지 않습니다.")
+    @field:NotBlank(message = "이메일은 필수 항목입니다.")
     val email: String?,
-    @field:NotBlank(message = "password is required")
+    @field:NotBlank(message = "비밀번호는 필수 항목입니다.")
     val password: String?,
-    @field:NotBlank(message = "location is required")
+    @field:NotBlank(message = "주소는 필수 항목입니다.")
     val location: String?,
     val imgUrl: String? = null,
 ) {

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/SignUpRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/SignUpRequest.kt
@@ -14,9 +14,9 @@ data class SignUpRequest(
     val password: String?,
     @field:NotBlank(message = "location is required")
     val location: String?,
-    val imageUrl: String? = null,
+    val imgUrl: String? = null,
 ) {
     fun toUser(): User {
-        return User(username!!, email!!, password!!, location!!, imageUrl = imageUrl)
+        return User(username!!, email!!, password!!, location!!, imgUrl = imgUrl)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/SignUpRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/SignUpRequest.kt
@@ -7,7 +7,7 @@ import javax.validation.constraints.Pattern
 
 data class SignUpRequest(
     @field:Pattern(
-        regexp = "^[\\p{L}\\p{Nd}가-힣]{1,10}\$",
+        regexp = "^([a-zA-Z0-9가-힣]){2,10}\$",
         message = "유저네임은 영문자, 숫자, 한글 중 하나 이상을 포함해야 하며, 1~10자 여야 합니다."
     )
     val username: String?,

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/SignUpRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/SignUpRequest.kt
@@ -6,14 +6,18 @@ import javax.validation.constraints.NotBlank
 import javax.validation.constraints.Pattern
 
 data class SignUpRequest(
-    @field:Pattern(regexp = "^[\\p{L}\\p{Nd}가-힣]{1,10}\$",
-    message = "유저네임은 영문자, 숫자, 한글 중 하나 이상을 포함해야 하며, 1~10자 여야 합니다.")
+    @field:Pattern(
+        regexp = "^[\\p{L}\\p{Nd}가-힣]{1,10}\$",
+        message = "유저네임은 영문자, 숫자, 한글 중 하나 이상을 포함해야 하며, 1~10자 여야 합니다."
+    )
     val username: String?,
     @field:Email(message = "이메일 형식이 올바르지 않습니다.")
     @field:NotBlank(message = "이메일은 필수 항목입니다.")
     val email: String?,
-    @field:Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@\$!%*#?&])[A-Za-z\\d@\$!%*#?&]{8,15}\$",
-        message = "비밀번호는 특수문자, 영문자, 숫자 포함 8~15자 여야 합니다")
+    @field:Pattern(
+        regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@\$!%*#?&])[A-Za-z\\d@\$!%*#?&]{8,15}\$",
+        message = "비밀번호는 특수문자, 영문자, 숫자 포함 8~15자 여야 합니다"
+    )
     val password: String?,
     @field:NotBlank(message = "주소는 필수 항목입니다.")
     val location: String?,

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/SignUpRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/SignUpRequest.kt
@@ -3,20 +3,22 @@ package com.wafflestudio.team03server.core.user.api.request
 import com.wafflestudio.team03server.core.user.entity.User
 import javax.validation.constraints.Email
 import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Pattern
 
 data class SignUpRequest(
-    @field:NotBlank(message = "유저네임은 필수 항목입니다.")
+    @field:Pattern(regexp = "^[\\p{L}\\p{Nd}가-힣]{1,10}\$",
+    message = "유저네임은 영문자, 숫자, 한글 중 하나 이상을 포함해야 하며, 1~10자 여야 합니다.")
     val username: String?,
     @field:Email(message = "이메일 형식이 올바르지 않습니다.")
     @field:NotBlank(message = "이메일은 필수 항목입니다.")
     val email: String?,
-    @field:NotBlank(message = "비밀번호는 필수 항목입니다.")
+    @field:Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@\$!%*#?&])[A-Za-z\\d@\$!%*#?&]{8,15}\$",
+        message = "비밀번호는 특수문자, 영문자, 숫자 포함 8~15자 여야 합니다")
     val password: String?,
     @field:NotBlank(message = "주소는 필수 항목입니다.")
     val location: String?,
-    val imgUrl: String? = null,
 ) {
     fun toUser(): User {
-        return User(username!!, email!!, password!!, location!!, imgUrl = imgUrl)
+        return User(username!!, email!!, password!!, location!!)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/response/UserResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/response/UserResponse.kt
@@ -1,0 +1,30 @@
+package com.wafflestudio.team03server.core.user.api.response
+
+import com.wafflestudio.team03server.core.user.entity.User
+import java.time.LocalDateTime
+
+data class UserResponse(
+    val id:Long,
+    val username:String,
+    val email:String,
+    val location:String,
+    val temperature:Double,
+    val imgUrl: String?,
+    val createdAt: LocalDateTime,
+    val modifiedAt: LocalDateTime
+){
+    companion object{
+        fun of(user: User):UserResponse{
+            return UserResponse(
+                user.id,
+                user.username,
+                user.email,
+                user.location,
+                user.temperature,
+                user.imgUrl,
+                user.createdAt!!,
+                user.modifiedAt!!
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/response/UserResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/response/UserResponse.kt
@@ -4,17 +4,17 @@ import com.wafflestudio.team03server.core.user.entity.User
 import java.time.LocalDateTime
 
 data class UserResponse(
-    val id:Long,
-    val username:String,
-    val email:String,
-    val location:String,
-    val temperature:Double,
+    val id: Long,
+    val username: String,
+    val email: String,
+    val location: String,
+    val temperature: Double,
     val imgUrl: String?,
     val createdAt: LocalDateTime,
     val modifiedAt: LocalDateTime
-){
-    companion object{
-        fun of(user: User):UserResponse{
+) {
+    companion object {
+        fun of(user: User): UserResponse {
             return UserResponse(
                 user.id,
                 user.username,

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/response/UserResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/response/UserResponse.kt
@@ -16,14 +16,14 @@ data class UserResponse(
     companion object {
         fun of(user: User): UserResponse {
             return UserResponse(
-                user.id,
-                user.username,
-                user.email,
-                user.location,
-                user.temperature,
-                user.imgUrl,
-                user.createdAt!!,
-                user.modifiedAt!!
+                id = user.id,
+                username = user.username,
+                email = user.email,
+                location = user.location,
+                temperature = user.temperature,
+                imgUrl = user.imgUrl,
+                createdAt = user.createdAt!!,
+                modifiedAt = user.modifiedAt!!
             )
         }
     }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/entity/User.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/entity/User.kt
@@ -11,17 +11,17 @@ import javax.validation.constraints.NotNull
 class User(
     @Column(unique = true)
     @NotNull
-    val username: String,
+    var username: String,
     @Column(unique = true)
     @NotNull
     val email: String,
     @NotNull
     var password: String,
     @NotNull
-    val location: String,
+    var location: String,
     @NotNull
     val temperature: Double = 36.5,
-    val imgUrl: String? = null,
+    var imgUrl: String? = null,
     @Column(unique = true)
     var verificationToken: String? = null,
     var emailVerified: Boolean = false,

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/entity/User.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/entity/User.kt
@@ -21,7 +21,7 @@ class User(
     val location: String,
     @NotNull
     val temperature: Double = 36.5,
-    val imageUrl: String? = null,
+    val imgUrl: String? = null,
     @Column(unique = true)
     var verificationToken: String? = null,
     var emailVerified: Boolean = false,

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/service/AuthService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/service/AuthService.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.team03server.core.user.service
 import com.wafflestudio.team03server.common.Exception400
 import com.wafflestudio.team03server.common.Exception403
 import com.wafflestudio.team03server.common.Exception404
+import com.wafflestudio.team03server.common.Exception409
 import com.wafflestudio.team03server.core.user.api.request.SignUpRequest
 import com.wafflestudio.team03server.core.user.api.response.LoginResponse
 import com.wafflestudio.team03server.core.user.api.response.SimpleUserResponse
@@ -17,9 +18,9 @@ import java.util.*
 interface AuthService {
     fun signUp(signUpRequest: SignUpRequest)
     fun sendVerificationMail(email: String)
-    fun checkEmailVerified(email: String): Boolean
-    fun checkDuplicatedEmail(email: String): Boolean
-    fun checkDuplicateUsername(username: String): Boolean
+    fun checkEmailVerified(email: String):Boolean
+    fun isDuplicateEmail(email: String): Boolean
+    fun isDuplicateUsername(username: String): Boolean
     fun verifyEmail(token: String)
     fun login(email: String, password: String): LoginResponse
 }
@@ -34,8 +35,12 @@ class AuthServiceImpl(
 ) : AuthService {
 
     override fun signUp(signUpRequest: SignUpRequest) {
-        checkDuplicatedEmail(signUpRequest.email!!)
-        checkDuplicateUsername(signUpRequest.username!!)
+        if(isDuplicateEmail(signUpRequest.email!!)){
+            throw Exception409("중복되는 이메일 입니다.")
+        }
+        if(isDuplicateUsername(signUpRequest.username!!)){
+            throw Exception409("중복되는 유저네임 입니다.")
+        }
         val user = signUpRequest.toUser()
         user.password = passwordEncoder.encode(user.password)
         // 인증 토큰 생성
@@ -60,12 +65,12 @@ class AuthServiceImpl(
         return user.emailVerified
     }
 
-    override fun checkDuplicatedEmail(email: String): Boolean {
-        return userRepository.findByEmail(email) == null
+    override fun isDuplicateEmail(email: String): Boolean {
+        return userRepository.findByEmail(email) != null
     }
 
-    override fun checkDuplicateUsername(username: String): Boolean {
-        return userRepository.findByUsername(username) == null
+    override fun isDuplicateUsername(username: String): Boolean {
+        return userRepository.findByUsername(username) != null
     }
 
     override fun verifyEmail(token: String) {

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/service/AuthService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/service/AuthService.kt
@@ -36,10 +36,10 @@ class AuthServiceImpl(
 
     override fun signUp(signUpRequest: SignUpRequest) {
         if(isDuplicateEmail(signUpRequest.email!!)){
-            throw Exception409("중복되는 이메일 입니다.")
+            throw Exception409("이미 존재하는 이메일 입니다.")
         }
         if(isDuplicateUsername(signUpRequest.username!!)){
-            throw Exception409("중복되는 유저네임 입니다.")
+            throw Exception409("이미 존재하는 유저네임 입니다.")
         }
         val user = signUpRequest.toUser()
         user.password = passwordEncoder.encode(user.password)

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/service/AuthService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/service/AuthService.kt
@@ -18,7 +18,7 @@ import java.util.*
 interface AuthService {
     fun signUp(signUpRequest: SignUpRequest)
     fun sendVerificationMail(email: String)
-    fun checkEmailVerified(email: String):Boolean
+    fun checkEmailVerified(email: String): Boolean
     fun isDuplicateEmail(email: String): Boolean
     fun isDuplicateUsername(username: String): Boolean
     fun verifyEmail(token: String)
@@ -35,10 +35,10 @@ class AuthServiceImpl(
 ) : AuthService {
 
     override fun signUp(signUpRequest: SignUpRequest) {
-        if(isDuplicateEmail(signUpRequest.email!!)){
+        if (isDuplicateEmail(signUpRequest.email!!)) {
             throw Exception409("이미 존재하는 이메일 입니다.")
         }
-        if(isDuplicateUsername(signUpRequest.username!!)){
+        if (isDuplicateUsername(signUpRequest.username!!)) {
             throw Exception409("이미 존재하는 유저네임 입니다.")
         }
         val user = signUpRequest.toUser()

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/service/UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/service/UserService.kt
@@ -30,7 +30,9 @@ class UserServiceImpl(
 
     override fun editProfile(userId: Long, editProfileRequest: EditProfileRequest): UserResponse {
         val user = userRepository.findByIdOrNull(userId) ?: throw Exception404("사용자를 찾을 수 없습니다.")
-        if (editProfileRequest.username != user.username && authService.isDuplicateUsername(editProfileRequest.username!!)) {
+        if (editProfileRequest.username != user.username &&
+            authService.isDuplicateUsername(editProfileRequest.username!!)
+        ) {
             throw Exception409("이미 존재하는 유저네임 입니다.")
         }
         user.username = editProfileRequest.username

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/service/UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/service/UserService.kt
@@ -47,6 +47,6 @@ class UserServiceImpl(
         if(editPasswordRequest.newPassword != editPasswordRequest.newPasswordConfirm){
             throw Exception400("비밀번호가 일치하지 않습니다.")
         }
-        user.password = editPasswordRequest.newPassword
+        user.password = passwordEncoder.encode(editPasswordRequest.newPassword)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/service/UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/service/UserService.kt
@@ -30,6 +30,7 @@ class UserServiceImpl(
 
     override fun editProfile(userId: Long, editProfileRequest: EditProfileRequest): UserResponse {
         val user = userRepository.findByIdOrNull(userId) ?: throw Exception404("사용자를 찾을 수 없습니다.")
+        // 유저네임 변경 감지 후 중복 체크
         if (editProfileRequest.username != user.username &&
             authService.isDuplicateUsername(editProfileRequest.username!!)
         ) {

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/service/UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/service/UserService.kt
@@ -1,0 +1,23 @@
+package com.wafflestudio.team03server.core.user.service
+
+import com.wafflestudio.team03server.common.Exception404
+import com.wafflestudio.team03server.core.user.api.response.UserResponse
+import com.wafflestudio.team03server.core.user.repository.UserRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+interface UserService{
+    fun getUser(userId:Long):UserResponse
+}
+
+@Service
+@Transactional
+class UserServiceImpl(
+    private val userRepository: UserRepository
+):UserService{
+    override fun getUser(userId: Long): UserResponse {
+        val user = userRepository.findByIdOrNull(userId) ?: throw Exception404("사용자를 찾을 수 없습니다.")
+        return UserResponse.of(user)
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/service/UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/service/UserService.kt
@@ -1,23 +1,52 @@
 package com.wafflestudio.team03server.core.user.service
 
-import com.wafflestudio.team03server.common.Exception404
+import com.wafflestudio.team03server.common.*
+import com.wafflestudio.team03server.core.user.api.request.EditPasswordRequest
+import com.wafflestudio.team03server.core.user.api.request.EditProfileRequest
 import com.wafflestudio.team03server.core.user.api.response.UserResponse
 import com.wafflestudio.team03server.core.user.repository.UserRepository
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 interface UserService{
-    fun getUser(userId:Long):UserResponse
+    fun getProfile(userId:Long):UserResponse
+    fun editProfile(userId:Long, editProfileRequest: EditProfileRequest):UserResponse
+    fun editPassword(userId: Long, editPasswordRequest: EditPasswordRequest)
 }
 
 @Service
 @Transactional
 class UserServiceImpl(
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val authService: AuthService,
+    private val passwordEncoder: PasswordEncoder
 ):UserService{
-    override fun getUser(userId: Long): UserResponse {
+    override fun getProfile(userId: Long): UserResponse {
         val user = userRepository.findByIdOrNull(userId) ?: throw Exception404("사용자를 찾을 수 없습니다.")
         return UserResponse.of(user)
+    }
+
+    override fun editProfile(userId: Long, editProfileRequest: EditProfileRequest): UserResponse {
+        val user = userRepository.findByIdOrNull(userId) ?: throw Exception404("사용자를 찾을 수 없습니다.")
+        if(editProfileRequest.username != user.username && authService.isDuplicateUsername(editProfileRequest.username!!)){
+            throw Exception409("이미 존재하는 유저네임 입니다.")
+        }
+        user.username = editProfileRequest.username
+        user.location = editProfileRequest.location!!
+        user.imgUrl = editProfileRequest.imgUrl
+        return UserResponse.of(user)
+    }
+
+    override fun editPassword(userId: Long, editPasswordRequest: EditPasswordRequest) {
+        val user = userRepository.findByIdOrNull(userId) ?: throw Exception404("사용자를 찾을 수 없습니다.")
+        if(!passwordEncoder.matches(editPasswordRequest.password,user.password)){
+            throw Exception403("기존 비밀번호가 틀렸습니다.")
+        }
+        if(editPasswordRequest.newPassword != editPasswordRequest.newPasswordConfirm){
+            throw Exception400("비밀번호가 일치하지 않습니다.")
+        }
+        user.password = editPasswordRequest.newPassword
     }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/service/UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/service/UserService.kt
@@ -10,9 +10,9 @@ import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
-interface UserService{
-    fun getProfile(userId:Long):UserResponse
-    fun editProfile(userId:Long, editProfileRequest: EditProfileRequest):UserResponse
+interface UserService {
+    fun getProfile(userId: Long): UserResponse
+    fun editProfile(userId: Long, editProfileRequest: EditProfileRequest): UserResponse
     fun editPassword(userId: Long, editPasswordRequest: EditPasswordRequest)
 }
 
@@ -22,7 +22,7 @@ class UserServiceImpl(
     private val userRepository: UserRepository,
     private val authService: AuthService,
     private val passwordEncoder: PasswordEncoder
-):UserService{
+) : UserService {
     override fun getProfile(userId: Long): UserResponse {
         val user = userRepository.findByIdOrNull(userId) ?: throw Exception404("사용자를 찾을 수 없습니다.")
         return UserResponse.of(user)
@@ -30,7 +30,7 @@ class UserServiceImpl(
 
     override fun editProfile(userId: Long, editProfileRequest: EditProfileRequest): UserResponse {
         val user = userRepository.findByIdOrNull(userId) ?: throw Exception404("사용자를 찾을 수 없습니다.")
-        if(editProfileRequest.username != user.username && authService.isDuplicateUsername(editProfileRequest.username!!)){
+        if (editProfileRequest.username != user.username && authService.isDuplicateUsername(editProfileRequest.username!!)) {
             throw Exception409("이미 존재하는 유저네임 입니다.")
         }
         user.username = editProfileRequest.username
@@ -41,10 +41,10 @@ class UserServiceImpl(
 
     override fun editPassword(userId: Long, editPasswordRequest: EditPasswordRequest) {
         val user = userRepository.findByIdOrNull(userId) ?: throw Exception404("사용자를 찾을 수 없습니다.")
-        if(!passwordEncoder.matches(editPasswordRequest.password,user.password)){
+        if (!passwordEncoder.matches(editPasswordRequest.password, user.password)) {
             throw Exception403("기존 비밀번호가 틀렸습니다.")
         }
-        if(editPasswordRequest.newPassword != editPasswordRequest.newPasswordConfirm){
+        if (editPasswordRequest.newPassword != editPasswordRequest.newPasswordConfirm) {
             throw Exception400("비밀번호가 일치하지 않습니다.")
         }
         user.password = passwordEncoder.encode(editPasswordRequest.newPassword)


### PR DESCRIPTION
## 🔑 Key Changes
- 유저 정보 반환 API GET /users/{user-id}
- 내 정보 API GET /users/me
- 내 정보 수정 API PATCH /users/me
- 비밀번호 변경 API PUT /users/me/password
## :computer: Test Result (기능 구현인 경우)
- 로컬에서 테스트 완료했습니다.
## 🙌 To Reviewers
- 회원가입시 이메일, 유저네임 중복 체크 안되던 것 수정했습니다.
- Request에 정규식 추가하고 에러 메세지 한글로 통일했습니다.
