### PR TITLE
Feat: 이메일 인증 방식 변경

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,9 @@ dependencies {
     // Apache IO
     implementation("commons-io:commons-io:2.11.0")
 
+    // Redis
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/Team03ServerApplication.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/Team03ServerApplication.kt
@@ -3,9 +3,11 @@ package com.wafflestudio.team03server
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.scheduling.annotation.EnableAsync
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableAsync
 class Team03ServerApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/wafflestudio/team03server/config/AwsConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/config/AwsConfig.kt
@@ -4,7 +4,7 @@ import com.amazonaws.auth.AWSStaticCredentialsProvider
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
-import com.wafflestudio.team03server.core.user.service.S3Properties
+import com.wafflestudio.team03server.properties.S3Properties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/AuthController.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/AuthController.kt
@@ -31,29 +31,22 @@ class AuthController(
     fun signUp(
         @Valid @RequestBody
         signUpRequest: SignUpRequest,
-    ): ResponseEntity<Any> {
-        authService.signUp(signUpRequest)
-        return ResponseEntity(HttpStatus.OK)
+    ): ResponseEntity<LoginResponse> {
+        val response = authService.signUp(signUpRequest)
+        return ResponseEntity(response, HttpStatus.OK)
     }
 
     // 인증 이메일 전송
     @GetMapping("/sendVerificationEmail")
     fun sendVerificationEmail(@RequestParam email: String): ResponseEntity<Any> {
-        authService.sendVerificationMail(email)
+        authService.sendVerificationEmail(email)
         return ResponseEntity(HttpStatus.OK)
-    }
-
-    // 이메일 인증 확인
-    @GetMapping("/checkEmailVerified")
-    fun checkEmailVerified(@RequestParam email: String): ResponseEntity<Boolean> {
-        return ResponseEntity(authService.checkEmailVerified(email), HttpStatus.OK)
     }
 
     // 이메일 인증
     @GetMapping("/verifyEmail")
-    fun verifyEmail(@RequestParam("token") token: String): ResponseEntity<Any> {
-        authService.verifyEmail(token)
-        return ResponseEntity(HttpStatus.OK)
+    fun verifyEmail(@RequestParam("code") code: String, @RequestParam("email") email: String): ResponseEntity<Boolean> {
+        return ResponseEntity(authService.verifyEmail(code, email), HttpStatus.OK)
     }
 
     // 로그인

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/UserController.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/UserController.kt
@@ -7,7 +7,7 @@ import com.wafflestudio.team03server.core.user.api.request.EditLocationRequest
 import com.wafflestudio.team03server.core.user.api.request.EditPasswordRequest
 import com.wafflestudio.team03server.core.user.api.request.EditUsernameRequest
 import com.wafflestudio.team03server.core.user.api.response.UserResponse
-import com.wafflestudio.team03server.core.user.service.S3Service
+import com.wafflestudio.team03server.utils.S3Service
 import com.wafflestudio.team03server.core.user.service.UserService
 import org.apache.commons.io.FilenameUtils
 import org.springframework.http.HttpStatus

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/entity/User.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/entity/User.kt
@@ -35,4 +35,4 @@ class User(
     @OneToMany(mappedBy = "user")
     var reservations: MutableList<Reservation> = mutableListOf(),
 
-    ) : BaseTimeEntity()
+) : BaseTimeEntity()

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/entity/User.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/entity/User.kt
@@ -25,9 +25,6 @@ class User(
     @NotNull
     val temperature: Double = 36.5,
     var imgUrl: String? = null,
-    @Column(unique = true)
-    var verificationToken: String? = null,
-    var emailVerified: Boolean = false,
 
     @OneToMany(mappedBy = "seller")
     var sellPosts: MutableList<TradePost> = mutableListOf(),
@@ -38,4 +35,4 @@ class User(
     @OneToMany(mappedBy = "user")
     var reservations: MutableList<Reservation> = mutableListOf(),
 
-) : BaseTimeEntity()
+    ) : BaseTimeEntity()

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/repository/UserRepository.kt
@@ -5,6 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserRepository : JpaRepository<User, Long> {
     fun findByEmail(email: String): User?
-    fun findByVerificationToken(verificationToken: String): User?
     fun findByUsername(username: String): User?
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/service/AuthService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/service/AuthService.kt
@@ -1,8 +1,6 @@
 package com.wafflestudio.team03server.core.user.service
 
-import com.wafflestudio.team03server.common.Exception400
 import com.wafflestudio.team03server.common.Exception403
-import com.wafflestudio.team03server.common.Exception404
 import com.wafflestudio.team03server.common.Exception409
 import com.wafflestudio.team03server.core.user.api.request.SignUpRequest
 import com.wafflestudio.team03server.core.user.api.response.LoginResponse
@@ -13,8 +11,6 @@ import com.wafflestudio.team03server.utils.RedisUtil
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.Duration
-import java.time.LocalDateTime
 import java.util.*
 
 interface AuthService {
@@ -55,7 +51,6 @@ class AuthServiceImpl(
         redisUtil.setDataExpire(email, code, 600000) // 10분
         emailService.sendVerificationEmail(email, code)
     }
-
 
     override fun isDuplicateEmail(email: String): Boolean {
         return userRepository.findByEmail(email) != null

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/service/AuthService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/service/AuthService.kt
@@ -8,6 +8,8 @@ import com.wafflestudio.team03server.core.user.api.request.SignUpRequest
 import com.wafflestudio.team03server.core.user.api.response.LoginResponse
 import com.wafflestudio.team03server.core.user.api.response.SimpleUserResponse
 import com.wafflestudio.team03server.core.user.repository.UserRepository
+import com.wafflestudio.team03server.utils.EmailService
+import com.wafflestudio.team03server.utils.RedisUtil
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -16,12 +18,11 @@ import java.time.LocalDateTime
 import java.util.*
 
 interface AuthService {
-    fun signUp(signUpRequest: SignUpRequest)
-    fun sendVerificationMail(email: String)
-    fun checkEmailVerified(email: String): Boolean
+    fun signUp(signUpRequest: SignUpRequest): LoginResponse
+    fun sendVerificationEmail(email: String)
     fun isDuplicateEmail(email: String): Boolean
     fun isDuplicateUsername(username: String): Boolean
-    fun verifyEmail(token: String)
+    fun verifyEmail(code: String, email: String): Boolean
     fun login(email: String, password: String): LoginResponse
 }
 
@@ -31,10 +32,11 @@ class AuthServiceImpl(
     private val userRepository: UserRepository,
     private val passwordEncoder: PasswordEncoder,
     private val emailService: EmailService,
-    private val authTokenService: AuthTokenService
+    private val authTokenService: AuthTokenService,
+    private val redisUtil: RedisUtil
 ) : AuthService {
 
-    override fun signUp(signUpRequest: SignUpRequest) {
+    override fun signUp(signUpRequest: SignUpRequest): LoginResponse {
         if (isDuplicateEmail(signUpRequest.email!!)) {
             throw Exception409("이미 존재하는 이메일 입니다.")
         }
@@ -43,27 +45,17 @@ class AuthServiceImpl(
         }
         val user = signUpRequest.toUser()
         user.password = passwordEncoder.encode(user.password)
-        // 인증 토큰 생성
-        val verificationToken = generateVerificationToken()
-        user.verificationToken = verificationToken
         userRepository.save(user)
-        emailService.sendVerificationEmail(signUpRequest.email, verificationToken)
+        val accessToken = authTokenService.generateTokenByEmail(signUpRequest.email).accessToken
+        return LoginResponse(accessToken, SimpleUserResponse.of(user))
     }
 
-    override fun sendVerificationMail(email: String) {
-        val user = userRepository.findByEmail(email) ?: throw Exception404("유저를 찾을 수 없습니다.")
-        if (user.emailVerified) {
-            throw Exception400("이미 인증 완료된 이메일입니다.")
-        }
-        val verificationToken = generateVerificationToken()
-        user.verificationToken = verificationToken
-        emailService.sendVerificationEmail(email, verificationToken)
+    override fun sendVerificationEmail(email: String) {
+        val code = generateRandomKey().toString()
+        redisUtil.setDataExpire(email, code, 600000) // 10분
+        emailService.sendVerificationEmail(email, code)
     }
 
-    override fun checkEmailVerified(email: String): Boolean {
-        val user = userRepository.findByEmail(email) ?: throw Exception404("유저를 찾을 수 없습니다.")
-        return user.emailVerified
-    }
 
     override fun isDuplicateEmail(email: String): Boolean {
         return userRepository.findByEmail(email) != null
@@ -73,18 +65,8 @@ class AuthServiceImpl(
         return userRepository.findByUsername(username) != null
     }
 
-    override fun verifyEmail(token: String) {
-        val user = userRepository.findByVerificationToken(token) ?: throw Exception404("토큰이 유효하지 않습니다.")
-        if (user.emailVerified) {
-            throw Exception403("이미 인증 완료된 이메일입니다.")
-        }
-        val diff = Duration.between(user.modifiedAt, LocalDateTime.now())
-        // 토큰 발급 후 30분 초과시 토큰 무효화
-        if (diff.toSeconds() > 1800) {
-            throw Exception400("인증 시간 초과")
-        }
-
-        user.emailVerified = true
+    override fun verifyEmail(code: String, email: String): Boolean {
+        return code == redisUtil.getData(email)
     }
 
     override fun login(email: String, password: String): LoginResponse {
@@ -92,14 +74,12 @@ class AuthServiceImpl(
         if (!passwordEncoder.matches(password, findUser.password)) {
             throw Exception403("이메일 또는 비밀번호가 잘못되었습니다.")
         }
-        if (!findUser.emailVerified) {
-            throw Exception400("이메일 인증이 필요합니다.")
-        }
         val accessToken = authTokenService.generateTokenByEmail(email).accessToken
         return LoginResponse(accessToken, SimpleUserResponse.of(findUser))
     }
 
-    private fun generateVerificationToken(): String {
-        return UUID.randomUUID().toString()
+    private fun generateRandomKey(): Int {
+        val random = Random()
+        return random.nextInt(900000) + 100000
     }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/service/AuthTokenService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/service/AuthTokenService.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.team03server.core.user.service
 import com.wafflestudio.team03server.common.Exception401
 import com.wafflestudio.team03server.common.Exception404
 import com.wafflestudio.team03server.core.user.repository.UserRepository
+import com.wafflestudio.team03server.properties.AuthProperties
 import io.jsonwebtoken.*
 import io.jsonwebtoken.security.Keys
 import org.springframework.boot.context.properties.EnableConfigurationProperties

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/service/OAuthService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/service/OAuthService.kt
@@ -35,15 +35,7 @@ class OAuthService(
             NEED_SIGNUP_MESSAGE,
             email,
         )
-        checkVerifiedUser(findUser)
         val jwtToken = authTokenService.generateTokenByEmail(findUser.email).accessToken
         return Pair(findUser, jwtToken)
-    }
-
-    private fun checkVerifiedUser(findUser: User) {
-        if (!findUser.emailVerified) {
-            userRepository.delete(findUser)
-            throw Exception404(NEED_SIGNUP_MESSAGE)
-        }
     }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/service/OAuthService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/service/OAuthService.kt
@@ -1,6 +1,5 @@
 package com.wafflestudio.team03server.core.user.service
 
-import com.wafflestudio.team03server.common.Exception404
 import com.wafflestudio.team03server.common.SocialLoginNotFoundException
 import com.wafflestudio.team03server.core.user.api.response.LoginResponse
 import com.wafflestudio.team03server.core.user.api.response.SimpleUserResponse

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/service/UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/service/UserService.kt
@@ -6,6 +6,7 @@ import com.wafflestudio.team03server.core.user.api.request.EditPasswordRequest
 import com.wafflestudio.team03server.core.user.api.request.EditUsernameRequest
 import com.wafflestudio.team03server.core.user.api.response.UserResponse
 import com.wafflestudio.team03server.core.user.repository.UserRepository
+import com.wafflestudio.team03server.utils.S3Service
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/com/wafflestudio/team03server/properties/AuthProperties.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/properties/AuthProperties.kt
@@ -1,4 +1,4 @@
-package com.wafflestudio.team03server.core.user.service
+package com.wafflestudio.team03server.properties
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.ConstructorBinding

--- a/src/main/kotlin/com/wafflestudio/team03server/properties/S3Properties.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/properties/S3Properties.kt
@@ -1,4 +1,4 @@
-package com.wafflestudio.team03server.core.user.service
+package com.wafflestudio.team03server.properties
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.ConstructorBinding

--- a/src/main/kotlin/com/wafflestudio/team03server/utils/EmailService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/utils/EmailService.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.team03server.utils
 
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.mail.javamail.MimeMessageHelper
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import javax.mail.internet.MimeMessage
 
@@ -21,6 +22,7 @@ class EmailService(
         mailSender.send(message)
     }
 
+    @Async
     fun sendVerificationEmail(email: String, code: String) {
         sendEmail(
             email,

--- a/src/main/kotlin/com/wafflestudio/team03server/utils/EmailService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/utils/EmailService.kt
@@ -1,4 +1,4 @@
-package com.wafflestudio.team03server.core.user.service
+package com.wafflestudio.team03server.utils
 
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.mail.javamail.MimeMessageHelper
@@ -21,11 +21,11 @@ class EmailService(
         mailSender.send(message)
     }
 
-    fun sendVerificationEmail(email: String, verificationToken: String) {
+    fun sendVerificationEmail(email: String, code: String) {
         sendEmail(
             email,
-            "회원가입 인증 이메일",
-            "http://localhost:8080/auth/verifyEmail?token=$verificationToken",
+            "회원가입 인증 코드",
+            "인증 코드: $code",
         )
     }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/utils/RedisUtil.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/utils/RedisUtil.kt
@@ -22,6 +22,4 @@ class RedisUtil(private val redisTemplate: StringRedisTemplate) {
     fun deleteData(key: String) {
         redisTemplate.delete(key)
     }
-
 }
-

--- a/src/main/kotlin/com/wafflestudio/team03server/utils/RedisUtil.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/utils/RedisUtil.kt
@@ -1,0 +1,27 @@
+package com.wafflestudio.team03server.utils
+
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.util.*
+
+@Component
+class RedisUtil(private val redisTemplate: StringRedisTemplate) {
+
+    fun getData(key: String): String? {
+        val valueOperations = redisTemplate.opsForValue()
+        return valueOperations.get(key)
+    }
+
+    fun setDataExpire(key: String, value: String, duration: Long) {
+        val valueOperations = redisTemplate.opsForValue()
+        val expireDuration = Duration.ofMillis(duration)
+        valueOperations.set(key, value, expireDuration)
+    }
+
+    fun deleteData(key: String) {
+        redisTemplate.delete(key)
+    }
+
+}
+

--- a/src/main/kotlin/com/wafflestudio/team03server/utils/S3Service.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/utils/S3Service.kt
@@ -1,4 +1,4 @@
-package com.wafflestudio.team03server.core.user.service
+package com.wafflestudio.team03server.utils
 
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.ObjectMetadata


### PR DESCRIPTION
## 🔑 Key Changes
- 이메일 인증 정보를 유저 db로부터 redis로 분리하였습니다.
- 이메일 전송 api 를 비동기 처리하였습니다.
- 회원가입 완료 후 바로 accessToken을 발급함으로써 바로 로그인 가능하도록 구현하였습니다.
## :computer: Test Result (기능 구현인 경우)
- 로컬에서 테스트 완료하였습니다.
## 🙌 To Reviewers
- 테스트 하시려면 로컬에 redis 설치하시고 하시면 됩니다.