### PR TITLE
Feat: 후기 생성, 조회, 삭제 기능 구현

### DIFF
--- a/src/main/kotlin/com/wafflestudio/team03server/core/trade/api/ReviewController.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/trade/api/ReviewController.kt
@@ -36,8 +36,9 @@ class ReviewController(
     }
 
     @Authenticated
-    @DeleteMapping("/users/me/review")
-    fun deleteReview() {
-        TODO()
+    @DeleteMapping("/reviews/{review-id}")
+    fun deleteReview(@UserContext userId: Long, @PathVariable("review-id") reviewId: Long): ResponseEntity<Any> {
+        reviewService.deleteReview(userId, reviewId)
+        return ResponseEntity(HttpStatus.OK)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/trade/api/ReviewController.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/trade/api/ReviewController.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.team03server.core.trade.api
+
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ReviewController {
+}

--- a/src/main/kotlin/com/wafflestudio/team03server/core/trade/api/ReviewController.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/trade/api/ReviewController.kt
@@ -1,7 +1,43 @@
 package com.wafflestudio.team03server.core.trade.api
 
+import com.wafflestudio.team03server.common.Authenticated
+import com.wafflestudio.team03server.common.UserContext
+import com.wafflestudio.team03server.core.trade.api.request.CreateReviewRequest
+import com.wafflestudio.team03server.core.trade.api.response.ReviewResponse
+import com.wafflestudio.team03server.core.trade.service.ReviewService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-class ReviewController {
+class ReviewController(
+    private val reviewService: ReviewService
+) {
+
+    @Authenticated
+    @PostMapping("/tradepost/{post-id}/review")
+    fun createReview(
+        @UserContext userId: Long,
+        @PathVariable("post-id") postId: Long,
+        createReviewRequest: CreateReviewRequest
+    ): ResponseEntity<Any> {
+        reviewService.createReview(userId, postId, createReviewRequest)
+        return ResponseEntity(HttpStatus.OK)
+    }
+
+    @GetMapping("/users/{user-id}/reviews")
+    fun getReviews(@PathVariable("user-id") userId: Long): ResponseEntity<List<ReviewResponse>> {
+        val reviews = reviewService.getReviews(userId)
+        return ResponseEntity(reviews, HttpStatus.OK)
+    }
+
+    @Authenticated
+    @DeleteMapping("/users/me/review")
+    fun deleteReview() {
+        TODO()
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/trade/api/request/CreateReviewRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/trade/api/request/CreateReviewRequest.kt
@@ -1,0 +1,6 @@
+package com.wafflestudio.team03server.core.trade.api.request
+
+data class CreateReviewRequest(
+    val score: Double,
+    val content: String?
+)

--- a/src/main/kotlin/com/wafflestudio/team03server/core/trade/api/response/ReviewResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/trade/api/response/ReviewResponse.kt
@@ -1,0 +1,22 @@
+package com.wafflestudio.team03server.core.trade.api.response
+
+import com.wafflestudio.team03server.core.trade.entity.Review
+import java.time.LocalDateTime
+
+data class ReviewResponse(
+    val username: String,
+    val location: String,
+    val createdAt: LocalDateTime,
+    val content: String?
+) {
+    companion object {
+        fun of(review: Review): ReviewResponse {
+            return ReviewResponse(
+                review.reviewer.username,
+                review.reviewer.location,
+                review.createdAt!!,
+                review.content
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/team03server/core/trade/entity/Review.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/trade/entity/Review.kt
@@ -1,0 +1,22 @@
+package com.wafflestudio.team03server.core.trade.entity
+
+import com.wafflestudio.team03server.common.BaseTimeEntity
+import com.wafflestudio.team03server.core.user.entity.User
+import javax.persistence.*
+import javax.validation.constraints.NotNull
+
+@Entity
+class Review(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trade_post_id")
+    val tradePost: TradePost,
+
+    @NotNull
+    val score: Double,
+    var content: String? = null,
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    val reviewer: Reviewer
+) : BaseTimeEntity() {
+}

--- a/src/main/kotlin/com/wafflestudio/team03server/core/trade/entity/Review.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/trade/entity/Review.kt
@@ -11,12 +11,32 @@ class Review(
     @JoinColumn(name = "trade_post_id")
     val tradePost: TradePost,
 
-    @NotNull
-    val score: Double,
-    var content: String? = null,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reviewer_id")
+    val reviewer: User,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reviewee_id")
+    val reviewee: User,
 
     @NotNull
-    @Enumerated(EnumType.STRING)
-    val reviewer: Reviewer
+    val score: Double,
+    var content: String? = null
 ) : BaseTimeEntity() {
+
+    companion object {
+        fun create(tradePost: TradePost, reviewer: User, reviewee: User, score: Double, content: String?): Review {
+            val review = Review(
+                tradePost = tradePost,
+                reviewer = reviewer,
+                reviewee = reviewee,
+                score = score,
+                content = content
+            )
+            reviewer.reviewsIWrote.add(review)
+            reviewee.reviewsIGot.add(review)
+            tradePost.reviews.add(review)
+            return review
+        }
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/trade/entity/Reviewer.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/trade/entity/Reviewer.kt
@@ -1,5 +1,0 @@
-package com.wafflestudio.team03server.core.trade.entity
-
-enum class Reviewer {
-    BUYER, SELLER
-}

--- a/src/main/kotlin/com/wafflestudio/team03server/core/trade/entity/Reviewer.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/trade/entity/Reviewer.kt
@@ -1,0 +1,5 @@
+package com.wafflestudio.team03server.core.trade.entity
+
+enum class Reviewer {
+    BUYER, SELLER
+}

--- a/src/main/kotlin/com/wafflestudio/team03server/core/trade/entity/TradePost.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/trade/entity/TradePost.kt
@@ -29,4 +29,7 @@ class TradePost(
     var tradeState: TradeState = TRADING,
     var viewCount: Int = 0,
 
+    @OneToMany(mappedBy = "tradePost")
+    var reviews: MutableList<Review> = mutableListOf()
+
 ) : BaseTimeEntity()

--- a/src/main/kotlin/com/wafflestudio/team03server/core/trade/repository/ReviewRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/trade/repository/ReviewRepository.kt
@@ -3,4 +3,6 @@ package com.wafflestudio.team03server.core.trade.repository
 import com.wafflestudio.team03server.core.trade.entity.Review
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface ReviewRepository : JpaRepository<Review, Long>
+interface ReviewRepository : JpaRepository<Review, Long> {
+    fun findByRevieweeIdAndContentIsNotNull(revieweeId: Long): List<Review>
+}

--- a/src/main/kotlin/com/wafflestudio/team03server/core/trade/repository/ReviewRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/trade/repository/ReviewRepository.kt
@@ -1,0 +1,6 @@
+package com.wafflestudio.team03server.core.trade.repository
+
+import com.wafflestudio.team03server.core.trade.entity.Review
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ReviewRepository : JpaRepository<Review, Long>

--- a/src/main/kotlin/com/wafflestudio/team03server/core/trade/service/ReviewService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/trade/service/ReviewService.kt
@@ -45,12 +45,23 @@ class ReviewService(
         return reviews
     }
 
+    fun deleteReview(userId: Long, reviewId: Long) {
+        val review = getReviewById(reviewId)
+        val reviewer = getUserById(userId)
+        checkReviewer(reviewer, review)
+        reviewRepository.delete(review)
+    }
+
     private fun getPostById(postId: Long): TradePost {
         return tradePostRepository.findByIdOrNull(postId) ?: throw Exception404("글을 찾을 수 없습니다.")
     }
 
     private fun getUserById(userId: Long): User {
         return userRepository.findByIdOrNull(userId) ?: throw Exception404("사용자를 찾을 수 없습니다.")
+    }
+
+    private fun getReviewById(reviewId: Long): Review {
+        return reviewRepository.findByIdOrNull(reviewId) ?: throw Exception404("후기를 찾을 수 없습니다.")
     }
 
     private fun checkTradeFinished(post: TradePost) {
@@ -62,6 +73,12 @@ class ReviewService(
     private fun checkReviewerBuyerOrSeller(reviewer: User, post: TradePost) {
         if (reviewer != post.buyer && reviewer != post.seller) {
             throw Exception403("거래 당사자만 후기를 작성할 수 있습니다.")
+        }
+    }
+
+    private fun checkReviewer(reviewer: User, review: Review) {
+        if (review.reviewer != reviewer) {
+            throw Exception403("내가 쓴 후기만 삭제할 수 있습니다.")
         }
     }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/trade/service/ReviewService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/trade/service/ReviewService.kt
@@ -1,0 +1,15 @@
+package com.wafflestudio.team03server.core.trade.service
+
+import org.springframework.stereotype.Service
+
+
+interface ReviewService {
+    fun createReview()
+}
+
+@Service
+class ReviewServiceImpl : ReviewService {
+    override fun createReview() {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/team03server/core/trade/service/ReviewService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/trade/service/ReviewService.kt
@@ -1,15 +1,67 @@
 package com.wafflestudio.team03server.core.trade.service
 
+import com.wafflestudio.team03server.common.Exception403
+import com.wafflestudio.team03server.common.Exception404
+import com.wafflestudio.team03server.core.trade.api.request.CreateReviewRequest
+import com.wafflestudio.team03server.core.trade.api.response.ReviewResponse
+import com.wafflestudio.team03server.core.trade.entity.Review
+import com.wafflestudio.team03server.core.trade.entity.TradePost
+import com.wafflestudio.team03server.core.trade.entity.TradeState
+import com.wafflestudio.team03server.core.trade.repository.ReviewRepository
+import com.wafflestudio.team03server.core.trade.repository.TradePostRepository
+import com.wafflestudio.team03server.core.user.entity.User
+import com.wafflestudio.team03server.core.user.repository.UserRepository
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
-
-
-interface ReviewService {
-    fun createReview()
-}
+import org.springframework.transaction.annotation.Transactional
+import kotlin.math.round
 
 @Service
-class ReviewServiceImpl : ReviewService {
-    override fun createReview() {
-        TODO("Not yet implemented")
+@Transactional
+class ReviewService(
+    private val tradePostRepository: TradePostRepository,
+    private val userRepository: UserRepository,
+    private val reviewRepository: ReviewRepository
+) {
+    fun createReview(reviewerId: Long, postId: Long, createReviewRequest: CreateReviewRequest) {
+        val post = getPostById(postId)
+        val reviewer = getUserById(reviewerId)
+        checkTradeFinished(post)
+        checkReviewerBuyerOrSeller(reviewer, post)
+        val reviewee = if (reviewer == post.seller) post.buyer else post.seller
+        val (score, content) = createReviewRequest
+        val review = Review.create(post, reviewer, reviewee!!, score, content)
+        reviewee.temperature = round((reviewee.temperature + score) * 10) / 10
+        reviewRepository.save(review)
+    }
+
+    fun getReviews(userId: Long): List<ReviewResponse> {
+        getUserById(userId)
+        val reviewEntities = reviewRepository.findByRevieweeIdAndContentIsNotNull(userId)
+        val reviews = mutableListOf<ReviewResponse>()
+        for (reviewEntity in reviewEntities) {
+            reviews.add(ReviewResponse.of(reviewEntity))
+        }
+        return reviews
+    }
+
+    private fun getPostById(postId: Long): TradePost {
+        return tradePostRepository.findByIdOrNull(postId) ?: throw Exception404("글을 찾을 수 없습니다.")
+    }
+
+    private fun getUserById(userId: Long): User {
+        return userRepository.findByIdOrNull(userId) ?: throw Exception404("사용자를 찾을 수 없습니다.")
+    }
+
+    private fun checkTradeFinished(post: TradePost) {
+        if (post.tradeState != TradeState.COMPLETED) {
+            throw Exception403("거래 완료 상태에서만 후기를 작성할 수 있습니다.")
+        }
+    }
+
+    private fun checkReviewerBuyerOrSeller(reviewer: User, post: TradePost) {
+        if (reviewer != post.buyer && reviewer != post.seller) {
+            throw Exception403("거래 당사자만 후기를 작성할 수 있습니다.")
+        }
     }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/EditPasswordRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/EditPasswordRequest.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.team03server.core.user.api.request
 
+import javax.validation.constraints.NotBlank
 import javax.validation.constraints.Pattern
 
 data class EditPasswordRequest(
@@ -8,6 +9,7 @@ data class EditPasswordRequest(
         regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@\$!%*#?&])[A-Za-z\\d@\$!%*#?&]{8,20}\$",
         message = "비밀번호는 특수문자, 영문자, 숫자 포함 8~20자 여야 합니다"
     )
+    @field:NotBlank(message = "비밀번호는 필수 항목입니다.")
     val newPassword: String?,
     val newPasswordConfirm: String
 )

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/EditUsernameRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/EditUsernameRequest.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.team03server.core.user.api.request
 
+import javax.validation.constraints.NotBlank
 import javax.validation.constraints.Pattern
 
 data class EditUsernameRequest(
@@ -7,5 +8,6 @@ data class EditUsernameRequest(
         regexp = "^([a-zA-Z0-9가-힣]){2,10}\$",
         message = "유저네임은 영문자, 숫자, 한글 중 하나 이상을 포함해야 하며, 2~10자 여야 합니다."
     )
+    @field:NotBlank(message = "유저네임은 필수 항목입니다.")
     val username: String?
 )

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/SignUpRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/SignUpRequest.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.team03server.core.user.api.request
 import com.wafflestudio.team03server.core.user.entity.User
 import javax.validation.constraints.Email
 import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotNull
 import javax.validation.constraints.Pattern
 
 data class SignUpRequest(
@@ -10,6 +11,7 @@ data class SignUpRequest(
         regexp = "^([a-zA-Z0-9가-힣]){2,10}\$",
         message = "유저네임은 영문자, 숫자, 한글 중 하나 이상을 포함해야 하며, 2~10자 여야 합니다."
     )
+    @field:NotBlank(message = "유저네임은 필수 항목입니다.")
     val username: String?,
     @field:Email(message = "이메일 형식이 올바르지 않습니다.")
     @field:NotBlank(message = "이메일은 필수 항목입니다.")
@@ -18,6 +20,7 @@ data class SignUpRequest(
         regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@\$!%*#?&])[A-Za-z\\d@\$!%*#?&]{8,20}\$",
         message = "비밀번호는 특수문자, 영문자, 숫자 포함 8~20자 여야 합니다"
     )
+    @field:NotBlank(message = "비밀번호는 필수 항목입니다.")
     val password: String?,
     @field:NotBlank(message = "주소는 필수 항목입니다.")
     val location: String?,

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/SignUpRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/SignUpRequest.kt
@@ -3,7 +3,6 @@ package com.wafflestudio.team03server.core.user.api.request
 import com.wafflestudio.team03server.core.user.entity.User
 import javax.validation.constraints.Email
 import javax.validation.constraints.NotBlank
-import javax.validation.constraints.NotNull
 import javax.validation.constraints.Pattern
 
 data class SignUpRequest(

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/entity/User.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/entity/User.kt
@@ -4,6 +4,7 @@ import com.wafflestudio.team03server.common.BaseTimeEntity
 import com.wafflestudio.team03server.core.trade.entity.LikePost
 import com.wafflestudio.team03server.core.trade.entity.TradePost
 import javax.persistence.CascadeType
+import com.wafflestudio.team03server.core.trade.entity.Review
 import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.OneToMany
@@ -24,7 +25,7 @@ class User(
     @NotNull
     var location: String,
     @NotNull
-    val temperature: Double = 36.5,
+    var temperature: Double = 36.5,
     var imgUrl: String? = null,
 
     @OneToMany(mappedBy = "seller")
@@ -35,5 +36,11 @@ class User(
 
     @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL])
     val likeTradePosts: MutableList<LikePost> = mutableListOf(),
+
+    @OneToMany(mappedBy = "reviewer")
+    var reviewsIWrote: MutableList<Review> = mutableListOf(),
+
+    @OneToMany(mappedBy = "reviewee")
+    var reviewsIGot: MutableList<Review> = mutableListOf()
 
 ) : BaseTimeEntity()


### PR DESCRIPTION
## 🔑 Key Changes
- 후기 생성 api POST /tradepost/{post-id}/review
- 후기 조회 api GET /users/{user-id}/reviews
- 후기 삭제 api DELETE /reviews/{review-id}
## :computer: Test Result (기능 구현인 경우)
- 로컬에서 테스트하였습니다.
## 🙌 To Reviewers
- 중고거래 후기 생성이 거래 끝나고 보통 발생하므로 거래에 종속적으로 api 설계를 하였습니다.
- 후기 조회는 나의 프로필 페이지나 다른 사람의 프로필 페이지를 볼때 사용될 것 같아 유저에 종속적으로 설계하였습니다.