### PR TITLE
Fix: 동네생활 페이징, 검색, 쿼리 최적화

### DIFF
--- a/src/main/kotlin/com/wafflestudio/team03server/config/QueryDslConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/config/QueryDslConfig.kt
@@ -1,3 +1,5 @@
+package com.wafflestudio.team03server.config
+
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration

--- a/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/api/NeighborController.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/api/NeighborController.kt
@@ -25,7 +25,7 @@ class NeighborController(
         @UserContext userId: Long,
         @RequestParam("name") neighborPostName: String?,
         @RequestParam("page", required = false, defaultValue = "1") page: Int?
-    ): Page<NeighborPostResponse> {
+    ): List<NeighborPostResponse> {
         val pageable = PageRequest.of(page!! -1, 50)
         return neighborPostService.getAllNeighborPosts(userId, neighborPostName, pageable)
     }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/api/NeighborController.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/api/NeighborController.kt
@@ -7,6 +7,8 @@ import com.wafflestudio.team03server.core.neighbor.api.response.NeighborPostResp
 import com.wafflestudio.team03server.core.neighbor.service.NeighborCommentService
 import com.wafflestudio.team03server.core.neighbor.service.NeighborPostService
 import com.wafflestudio.team03server.core.neighbor.service.NeighborReplyService
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import org.springframework.web.bind.annotation.*
 import javax.validation.Valid
 
@@ -19,8 +21,13 @@ class NeighborController(
 ) {
     @Authenticated
     @GetMapping("")
-    fun getAllNeighborPosts(@UserContext userId: Long): List<NeighborPostResponse> {
-        return neighborPostService.getAllNeighborPosts(userId)
+    fun getAllNeighborPosts(
+        @UserContext userId: Long,
+        @RequestParam("name") neighborPostName: String?,
+        @RequestParam("page", required = false, defaultValue = "1") page: Int?
+    ): Page<NeighborPostResponse> {
+        val pageable = PageRequest.of(page!! -1, 50)
+        return neighborPostService.getAllNeighborPosts(userId, neighborPostName, pageable)
     }
 
     @Authenticated

--- a/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/api/NeighborController.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/api/NeighborController.kt
@@ -7,7 +7,6 @@ import com.wafflestudio.team03server.core.neighbor.api.response.NeighborPostResp
 import com.wafflestudio.team03server.core.neighbor.service.NeighborCommentService
 import com.wafflestudio.team03server.core.neighbor.service.NeighborPostService
 import com.wafflestudio.team03server.core.neighbor.service.NeighborReplyService
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.web.bind.annotation.*
 import javax.validation.Valid
@@ -26,7 +25,7 @@ class NeighborController(
         @RequestParam("name") neighborPostName: String?,
         @RequestParam("page", required = false, defaultValue = "1") page: Int?
     ): List<NeighborPostResponse> {
-        val pageable = PageRequest.of(page!! -1, 50)
+        val pageable = PageRequest.of(page!! - 1, 50)
         return neighborPostService.getAllNeighborPosts(userId, neighborPostName, pageable)
     }
 

--- a/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/api/NeighborController.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/api/NeighborController.kt
@@ -17,9 +17,10 @@ class NeighborController(
     val neighborCommentService: NeighborCommentService,
     val neighborReplyService: NeighborReplyService
 ) {
+    @Authenticated
     @GetMapping("")
-    fun getAllNeighborPosts(): List<NeighborPostResponse> {
-        return neighborPostService.getAllNeighborPosts()
+    fun getAllNeighborPosts(@UserContext userId: Long): List<NeighborPostResponse> {
+        return neighborPostService.getAllNeighborPosts(userId)
     }
 
     @Authenticated
@@ -31,9 +32,13 @@ class NeighborController(
         return neighborPostService.createNeighborPost(userId, createNeighborPostRequest)
     }
 
+    @Authenticated
     @GetMapping("/{postId}")
-    fun getNeighborPost(@PathVariable("postId") postId: Long): NeighborPostResponse {
-        return neighborPostService.getNeighborPost(postId)
+    fun getNeighborPost(
+        @PathVariable("postId") postId: Long,
+        @UserContext userId: Long
+    ): NeighborPostResponse {
+        return neighborPostService.getNeighborPost(userId, postId)
     }
 
     @Authenticated

--- a/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/api/response/NeighborPostResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/api/response/NeighborPostResponse.kt
@@ -12,10 +12,11 @@ data class NeighborPostResponse(
     val comments: List<NeighborCommentResponse>,
     val viewCount: Int,
     val likeCount: Int,
+    val isLiked: Boolean? = false,
     val createdAt: LocalDateTime?
 ) {
     companion object {
-        fun of(post: NeighborPost): NeighborPostResponse {
+        fun of(post: NeighborPost, userId: Long): NeighborPostResponse {
             return NeighborPostResponse(
                 postId = post.id,
                 title = post.title,
@@ -24,6 +25,7 @@ data class NeighborPostResponse(
                 comments = post.comments.map { NeighborCommentResponse.of(it) },
                 viewCount = post.viewCount,
                 likeCount = post.likes.filter { !it.deleteStatus }.size,
+                isLiked = post.likes.any { !it.deleteStatus && it.liker.id == userId },
                 createdAt = post.createdAt
             )
         }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/repository/NeighborPostRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/repository/NeighborPostRepository.kt
@@ -1,6 +1,10 @@
 package com.wafflestudio.team03server.core.neighbor.repository
 
 import com.wafflestudio.team03server.core.neighbor.entity.NeighborPost
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface NeighborPostRepository : JpaRepository<NeighborPost, Long>
+interface NeighborPostRepository : JpaRepository<NeighborPost, Long> {
+    fun findAllByTitleContains(neighborPostName: String, pageable: Pageable): Page<NeighborPost>
+}

--- a/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/repository/NeighborPostRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/repository/NeighborPostRepository.kt
@@ -1,10 +1,47 @@
 package com.wafflestudio.team03server.core.neighbor.repository
 
+import com.querydsl.jpa.impl.JPAQueryFactory
 import com.wafflestudio.team03server.core.neighbor.entity.NeighborPost
-import org.springframework.data.domain.Page
+import com.wafflestudio.team03server.core.neighbor.entity.QNeighborComment.neighborComment
+import com.wafflestudio.team03server.core.neighbor.entity.QNeighborPost.neighborPost
+import com.wafflestudio.team03server.core.user.entity.QUser.user
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Component
 
-interface NeighborPostRepository : JpaRepository<NeighborPost, Long> {
-    fun findAllByTitleContains(neighborPostName: String, pageable: Pageable): Page<NeighborPost>
+interface NeighborPostRepository : JpaRepository<NeighborPost, Long>, NeighborPostSupport
+
+interface NeighborPostSupport {
+    fun findAllByQuerydsl(pageable: Pageable): List<NeighborPost>
+    fun findAllByTitleContains(neighborPostName: String, pageable: Pageable): List<NeighborPost>
+}
+
+@Component
+class NeighborPostSupportImpl(
+    private val queryFactory: JPAQueryFactory
+): NeighborPostSupport {
+    override fun findAllByQuerydsl(pageable: Pageable): List<NeighborPost> {
+        return queryFactory
+            .selectFrom(neighborPost)
+            .leftJoin(neighborPost.publisher, user)
+            .fetchJoin()
+            .leftJoin(neighborPost.comments, neighborComment)
+            .fetchJoin()
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+    }
+
+    override fun findAllByTitleContains(neighborPostName: String, pageable: Pageable): List<NeighborPost> {
+        return queryFactory
+            .selectFrom(neighborPost)
+            .where(neighborPost.title.contains(neighborPostName))
+            .leftJoin(neighborPost.publisher, user)
+            .fetchJoin()
+            .leftJoin(neighborPost.comments, neighborComment)
+            .fetchJoin()
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/repository/NeighborPostRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/repository/NeighborPostRepository.kt
@@ -19,7 +19,7 @@ interface NeighborPostSupport {
 @Component
 class NeighborPostSupportImpl(
     private val queryFactory: JPAQueryFactory
-): NeighborPostSupport {
+) : NeighborPostSupport {
     override fun findAllByQuerydsl(pageable: Pageable): List<NeighborPost> {
         return queryFactory
             .selectFrom(neighborPost)

--- a/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/repository/NeighborPostRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/repository/NeighborPostRepository.kt
@@ -29,6 +29,7 @@ class NeighborPostSupportImpl(
             .fetchJoin()
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
+            .distinct()
             .fetch()
     }
 
@@ -42,6 +43,7 @@ class NeighborPostSupportImpl(
             .fetchJoin()
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
+            .distinct()
             .fetch()
     }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/service/NeighborPostService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/service/NeighborPostService.kt
@@ -12,12 +12,14 @@ import com.wafflestudio.team03server.core.neighbor.repository.NeighborLikeReposi
 import com.wafflestudio.team03server.core.neighbor.repository.NeighborPostRepository
 import com.wafflestudio.team03server.core.user.entity.User
 import com.wafflestudio.team03server.core.user.repository.UserRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 interface NeighborPostService {
-    fun getAllNeighborPosts(userId: Long): List<NeighborPostResponse>
+    fun getAllNeighborPosts(userId: Long, neighborPostName: String?, pageable: Pageable): Page<NeighborPostResponse>
     fun createNeighborPost(userId: Long, createNeighborPostRequest: CreateNeighborPostRequest): NeighborPostResponse
     fun getNeighborPost(userId: Long, postId: Long): NeighborPostResponse
     fun updateNeighborPost(
@@ -25,7 +27,6 @@ interface NeighborPostService {
         postId: Long,
         updateNeighborPostRequest: UpdateNeighborPostRequest
     ): NeighborPostResponse
-
     fun deleteNeighborPost(userId: Long, postId: Long)
     fun likeOrUnlikeNeighborPost(userId: Long, postId: Long)
 }
@@ -38,8 +39,10 @@ class NeighborPostServiceImpl(
     val neighborLikeRepository: NeighborLikeRepository
 ) : NeighborPostService {
 
-    override fun getAllNeighborPosts(userId: Long): List<NeighborPostResponse> {
-        return neighborPostRepository.findAll().map { NeighborPostResponse.of(it, userId) }
+    override fun getAllNeighborPosts(userId: Long, neighborPostName: String?, pageable: Pageable): Page<NeighborPostResponse> {
+        neighborPostName?.let {
+            return neighborPostRepository.findAllByTitleContains(neighborPostName, pageable).map { NeighborPostResponse.of(it, userId) }
+        } ?: return neighborPostRepository.findAll(pageable).map { NeighborPostResponse.of(it, userId) }
     }
 
     private fun getUserById(userId: Long) = userRepository.findByIdOrNull(userId) ?: throw Exception404("유효한 회원이 아닙니다.")

--- a/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/service/NeighborPostService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/service/NeighborPostService.kt
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 interface NeighborPostService {
-    fun getAllNeighborPosts(userId: Long, neighborPostName: String?, pageable: Pageable): Page<NeighborPostResponse>
+    fun getAllNeighborPosts(userId: Long, neighborPostName: String?, pageable: Pageable): List<NeighborPostResponse>
     fun createNeighborPost(userId: Long, createNeighborPostRequest: CreateNeighborPostRequest): NeighborPostResponse
     fun getNeighborPost(userId: Long, postId: Long): NeighborPostResponse
     fun updateNeighborPost(
@@ -39,10 +39,11 @@ class NeighborPostServiceImpl(
     val neighborLikeRepository: NeighborLikeRepository
 ) : NeighborPostService {
 
-    override fun getAllNeighborPosts(userId: Long, neighborPostName: String?, pageable: Pageable): Page<NeighborPostResponse> {
+    override fun getAllNeighborPosts(userId: Long, neighborPostName: String?, pageable: Pageable): List<NeighborPostResponse> {
         neighborPostName?.let {
-            return neighborPostRepository.findAllByTitleContains(neighborPostName, pageable).map { NeighborPostResponse.of(it, userId) }
-        } ?: return neighborPostRepository.findAll(pageable).map { NeighborPostResponse.of(it, userId) }
+            return neighborPostRepository.findAllByTitleContains(neighborPostName, pageable)
+                .map { NeighborPostResponse.of(it, userId) }
+        } ?: return neighborPostRepository.findAllByQuerydsl(pageable).map { NeighborPostResponse.of(it, userId)}
     }
 
     private fun getUserById(userId: Long) = userRepository.findByIdOrNull(userId) ?: throw Exception404("유효한 회원이 아닙니다.")

--- a/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/service/NeighborPostService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/service/NeighborPostService.kt
@@ -12,7 +12,6 @@ import com.wafflestudio.team03server.core.neighbor.repository.NeighborLikeReposi
 import com.wafflestudio.team03server.core.neighbor.repository.NeighborPostRepository
 import com.wafflestudio.team03server.core.user.entity.User
 import com.wafflestudio.team03server.core.user.repository.UserRepository
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -27,6 +26,7 @@ interface NeighborPostService {
         postId: Long,
         updateNeighborPostRequest: UpdateNeighborPostRequest
     ): NeighborPostResponse
+
     fun deleteNeighborPost(userId: Long, postId: Long)
     fun likeOrUnlikeNeighborPost(userId: Long, postId: Long)
 }
@@ -39,11 +39,15 @@ class NeighborPostServiceImpl(
     val neighborLikeRepository: NeighborLikeRepository
 ) : NeighborPostService {
 
-    override fun getAllNeighborPosts(userId: Long, neighborPostName: String?, pageable: Pageable): List<NeighborPostResponse> {
+    override fun getAllNeighborPosts(
+        userId: Long,
+        neighborPostName: String?,
+        pageable: Pageable
+    ): List<NeighborPostResponse> {
         neighborPostName?.let {
             return neighborPostRepository.findAllByTitleContains(neighborPostName, pageable)
                 .map { NeighborPostResponse.of(it, userId) }
-        } ?: return neighborPostRepository.findAllByQuerydsl(pageable).map { NeighborPostResponse.of(it, userId)}
+        } ?: return neighborPostRepository.findAllByQuerydsl(pageable).map { NeighborPostResponse.of(it, userId) }
     }
 
     private fun getUserById(userId: Long) = userRepository.findByIdOrNull(userId) ?: throw Exception404("유효한 회원이 아닙니다.")

--- a/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/service/NeighborPostService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/service/NeighborPostService.kt
@@ -17,9 +17,9 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 interface NeighborPostService {
-    fun getAllNeighborPosts(): List<NeighborPostResponse>
+    fun getAllNeighborPosts(userId: Long): List<NeighborPostResponse>
     fun createNeighborPost(userId: Long, createNeighborPostRequest: CreateNeighborPostRequest): NeighborPostResponse
-    fun getNeighborPost(postId: Long): NeighborPostResponse
+    fun getNeighborPost(userId: Long, postId: Long): NeighborPostResponse
     fun updateNeighborPost(
         userId: Long,
         postId: Long,
@@ -38,8 +38,8 @@ class NeighborPostServiceImpl(
     val neighborLikeRepository: NeighborLikeRepository
 ) : NeighborPostService {
 
-    override fun getAllNeighborPosts(): List<NeighborPostResponse> {
-        return neighborPostRepository.findAll().map { NeighborPostResponse.of(it) }
+    override fun getAllNeighborPosts(userId: Long): List<NeighborPostResponse> {
+        return neighborPostRepository.findAll().map { NeighborPostResponse.of(it, userId) }
     }
 
     private fun getUserById(userId: Long) = userRepository.findByIdOrNull(userId) ?: throw Exception404("유효한 회원이 아닙니다.")
@@ -52,7 +52,7 @@ class NeighborPostServiceImpl(
         val (title, content) = createNeighborPostRequest
         val neighborPost = NeighborPost(title = title!!, content = content!!, publisher = publisher)
         neighborPostRepository.save(neighborPost)
-        return NeighborPostResponse.of(neighborPost)
+        return NeighborPostResponse.of(neighborPost, userId)
     }
 
     private fun getNeighborPostById(postId: Long) =
@@ -62,10 +62,10 @@ class NeighborPostServiceImpl(
         post.viewCount += 1
     }
 
-    override fun getNeighborPost(postId: Long): NeighborPostResponse {
+    override fun getNeighborPost(userId: Long, postId: Long): NeighborPostResponse {
         val readPost = getNeighborPostById(postId)
         updateViewCount(readPost)
-        return NeighborPostResponse.of(readPost)
+        return NeighborPostResponse.of(readPost, userId)
     }
 
     private fun checkPublisher(readPost: NeighborPost, userId: Long) {
@@ -85,7 +85,7 @@ class NeighborPostServiceImpl(
         val readPost = getNeighborPostById(postId)
         checkPublisher(readPost, userId)
         updateNeighborPostByRequest(readPost, updateNeighborPostRequest)
-        return NeighborPostResponse.of(readPost)
+        return NeighborPostResponse.of(readPost, userId)
     }
 
     override fun deleteNeighborPost(userId: Long, postId: Long) {

--- a/src/test/kotlin/com/wafflestudio/team03server/core/neighbor/service/NeighborPostServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/team03server/core/neighbor/service/NeighborPostServiceTest.kt
@@ -40,10 +40,10 @@ internal class NeighborPostServiceTest @Autowired constructor(
     fun getAllNeighborPosts() {
         // given
         val user1 = createUser("user1", "user1@me.com", "abcd!1234")
-        (1..10).map { createPost("제목${it}", "내용", user1) }
+        (1..10).map { createPost("제목$it", "내용", user1) }
 
         // when
-        val pageable = PageRequest.of( 0, 50)
+        val pageable = PageRequest.of(0, 50)
         val neighborPosts = neighborPostService.getAllNeighborPosts(user1.id, null, pageable)
 
         // then
@@ -55,16 +55,15 @@ internal class NeighborPostServiceTest @Autowired constructor(
     fun searchNeighborPosts() {
         // given
         val user1 = createUser("user1", "user1@me.com", "abcd!1234")
-        (1..10).map { createPost("제목${it}", "내용", user1) }
+        (1..10).map { createPost("제목$it", "내용", user1) }
         val targetPost = createPost("삼겹살", "맛있다", user1)
 
         // when
-        val pageable = PageRequest.of( 0, 50)
+        val pageable = PageRequest.of(0, 50)
         val neighborPosts = neighborPostService.getAllNeighborPosts(user1.id, "삼겹살", pageable)
 
         // then
         assertThat(neighborPosts.size).isEqualTo(1)
-
     }
 
     @Test
@@ -91,7 +90,7 @@ internal class NeighborPostServiceTest @Autowired constructor(
     fun getNeighborPost() {
         // given
         val user1 = createUser("user1", "user1@me.com", "abcd!1234")
-        (1..10).map { createPost("제목${it}", "내용", user1) }
+        (1..10).map { createPost("제목$it", "내용", user1) }
         val targetPost = createPost("삼겹살", "맛있다", user1)
 
         // when
@@ -112,7 +111,7 @@ internal class NeighborPostServiceTest @Autowired constructor(
     fun updateNeighborPost() {
         // given
         val user1 = createUser("user1", "user1@me.com", "abcd!1234")
-        (1..10).map { createPost("제목${it}", "내용", user1) }
+        (1..10).map { createPost("제목$it", "내용", user1) }
         val targetPost = createPost("삼겹살", "맛있다", user1)
 
         // when
@@ -130,7 +129,7 @@ internal class NeighborPostServiceTest @Autowired constructor(
     fun deleteNeighborPost() {
         // given
         val user1 = createUser("user1", "user1@me.com", "abcd!1234")
-        (1..10).map { createPost("제목${it}", "내용", user1) }
+        (1..10).map { createPost("제목$it", "내용", user1) }
         val targetPost = createPost("삼겹살", "맛있다", user1)
 
         // when

--- a/src/test/kotlin/com/wafflestudio/team03server/core/neighbor/service/NeighborPostServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/team03server/core/neighbor/service/NeighborPostServiceTest.kt
@@ -1,0 +1,175 @@
+package com.wafflestudio.team03server.core.neighbor.service
+
+import com.wafflestudio.team03server.core.neighbor.api.request.CreateNeighborPostRequest
+import com.wafflestudio.team03server.core.neighbor.api.request.UpdateNeighborPostRequest
+import com.wafflestudio.team03server.core.neighbor.entity.NeighborPost
+import com.wafflestudio.team03server.core.neighbor.repository.NeighborLikeRepository
+import com.wafflestudio.team03server.core.neighbor.repository.NeighborPostRepository
+import com.wafflestudio.team03server.core.user.entity.User
+import com.wafflestudio.team03server.core.user.repository.UserRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.PageRequest
+import org.springframework.transaction.annotation.Transactional
+
+@SpringBootTest
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
+@Transactional
+internal class NeighborPostServiceTest @Autowired constructor(
+    val userRepository: UserRepository,
+    val neighborPostRepository: NeighborPostRepository,
+    val neighborPostService: NeighborPostService,
+    val neighborLikeRepository: NeighborLikeRepository
+) {
+    @BeforeEach
+    private fun deleteAll() {
+        userRepository.deleteAll()
+        neighborPostRepository.deleteAll()
+    }
+
+    @Test
+    @DisplayName("게시글 조회 성공")
+    fun getAllNeighborPosts() {
+        // given
+        val user1 = createUser("user1", "user1@me.com", "abcd!1234")
+        (1..10).map { createPost("제목${it}", "내용", user1) }
+
+        // when
+        val pageable = PageRequest.of( 0, 50)
+        val neighborPosts = neighborPostService.getAllNeighborPosts(user1.id, null, pageable)
+
+        // then
+        assertThat(neighborPosts.size).isEqualTo(10)
+    }
+
+    @Test
+    @DisplayName("게시글 검색 성공")
+    fun searchNeighborPosts() {
+        // given
+        val user1 = createUser("user1", "user1@me.com", "abcd!1234")
+        (1..10).map { createPost("제목${it}", "내용", user1) }
+        val targetPost = createPost("삼겹살", "맛있다", user1)
+
+        // when
+        val pageable = PageRequest.of( 0, 50)
+        val neighborPosts = neighborPostService.getAllNeighborPosts(user1.id, "삼겹살", pageable)
+
+        // then
+        assertThat(neighborPosts.size).isEqualTo(1)
+
+    }
+
+    @Test
+    @DisplayName("게시글 생성 성공")
+    fun createNeighborPost() {
+        // given
+        val user1 = createUser("user1", "user1@me.com", "abcd!1234")
+        val request = CreateNeighborPostRequest("제목", "내용")
+
+        // when
+        val response = neighborPostService.createNeighborPost(user1.id, request)
+
+        // then
+        assertThat(response.title).isEqualTo(request.title)
+        assertThat(response.content).isEqualTo(request.content)
+        assertThat(response.publisher.id).isEqualTo(user1.id)
+        assertThat(response.comments.size).isEqualTo(0)
+        assertThat(response.likeCount).isEqualTo(0)
+        assertThat(response.viewCount).isEqualTo(0)
+    }
+
+    @Test
+    @DisplayName("게시글 상세 조회 성공")
+    fun getNeighborPost() {
+        // given
+        val user1 = createUser("user1", "user1@me.com", "abcd!1234")
+        (1..10).map { createPost("제목${it}", "내용", user1) }
+        val targetPost = createPost("삼겹살", "맛있다", user1)
+
+        // when
+        val findPost = neighborPostService.getNeighborPost(user1.id, targetPost.id)
+
+        // then
+        assertThat(findPost.postId).isEqualTo(targetPost.id)
+        assertThat(findPost.title).isEqualTo(targetPost.title)
+        assertThat(findPost.content).isEqualTo(targetPost.content)
+        assertThat(findPost.publisher.id).isEqualTo(user1.id)
+        assertThat(findPost.comments.size).isEqualTo(targetPost.comments.size)
+        assertThat(findPost.likeCount).isEqualTo(targetPost.likes.size)
+        assertThat(findPost.viewCount).isEqualTo(targetPost.viewCount)
+    }
+
+    @Test
+    @DisplayName("게시글 수정 성공")
+    fun updateNeighborPost() {
+        // given
+        val user1 = createUser("user1", "user1@me.com", "abcd!1234")
+        (1..10).map { createPost("제목${it}", "내용", user1) }
+        val targetPost = createPost("삼겹살", "맛있다", user1)
+
+        // when
+        val request = UpdateNeighborPostRequest("목살", "괜찮다")
+        val updatedPost = neighborPostService.updateNeighborPost(user1.id, targetPost.id, request)
+
+        // then
+        assertThat(updatedPost.postId).isEqualTo(targetPost.id)
+        assertThat(updatedPost.title).isEqualTo(request.title)
+        assertThat(updatedPost.content).isEqualTo(request.content)
+    }
+
+    @Test
+    @DisplayName("게시글 삭제 성공")
+    fun deleteNeighborPost() {
+        // given
+        val user1 = createUser("user1", "user1@me.com", "abcd!1234")
+        (1..10).map { createPost("제목${it}", "내용", user1) }
+        val targetPost = createPost("삼겹살", "맛있다", user1)
+
+        // when
+        neighborPostService.deleteNeighborPost(user1.id, targetPost.id)
+
+        // then
+        val pageable = PageRequest.of(0, 50)
+        val posts = neighborPostService.getAllNeighborPosts(user1.id, null, pageable)
+        assertThat(posts.size).isEqualTo(10)
+    }
+
+    @Test
+    @DisplayName("게시글 좋아요 성공")
+    fun likeOrUnlikeNeighborPost() {
+        // given
+        val user1 = createUser("user1", "user1@me.com", "abcd!1234")
+        val user2 = createUser("user2", "user2@me.com", "abcd!1234")
+        val post = createPost("제목", "내용", user1)
+
+        // when
+        neighborPostService.likeOrUnlikeNeighborPost(user2.id, post.id)
+        val like = neighborLikeRepository.findNeighborLikeByLikedPostAndLiker(post, user2)
+
+        // then
+        assertThat(like).isNotNull
+        assertThat(post.likes.size).isEqualTo(1)
+        assertThat(post.likes[0].liker.id).isEqualTo(user2.id)
+        assertThat(post.likes[0].likedPost.id).isEqualTo(post.id)
+    }
+
+    private fun createUser(username: String, email: String, password: String, location: String = "관악구"): User {
+        val user = User(username, email, password, location)
+        userRepository.save(user)
+        return user
+    }
+
+    private fun createPost(title: String, content: String, user: User): NeighborPost {
+        val post = NeighborPost(title, content, user)
+        neighborPostRepository.save(post)
+        return post
+    }
+}


### PR DESCRIPTION
## 🔑 Key Changes
- 동네생활 글이 로그인한 유저에게만 보이도록 변경했습니다.
- 페이징을 적용했습니다. 이 과정에서 혹시 필요할까 싶어서 getAllNeighborPosts에 제목 검색 기능을 넣었습니다.
- N+1 문제를 보완하기 위해 querydsl에서 fetch join을 사용했습니다.
## :computer: Test Result (기능 구현인 경우)
- 로컬에서 테스트 완료했습니다.
## 🙌 To Reviewers
- 현재 post에 연결된 게 user, comment, like인데 user, comment까지만 fetch join이 가능하고 like부터는 에러가 발생해서 일단 두 개만 fetch join을 해놓았습니다. 그런데 comment를 불러오는 과정에서 user와 reply에 쿼리를 보내서 N+1 문제가 완전히 보완되지는 못했습니다. join하는 테이블에 제3의 테이블을 join해야 하는 상황이라 해당 부분은 좀 더 찾아보고 더 보완하겠습니다. 혹시 아시는 바가 있으면 조언 부탁드립니다ㅠ
- QueryDslConfig에 package가 안 적혀있어서 오류가 있었습니다..이 pr이 적용되면 다시 잘 작동할 겁니다..
## ScreenShot (optional)
