### PR TITLE
Fix: 불필요한 ec2 metadata 불러오지 않도록 수정

### DIFF
--- a/src/main/kotlin/com/wafflestudio/team03server/config/AwsConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/config/AwsConfig.kt
@@ -5,12 +5,15 @@ import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.wafflestudio.team03server.properties.S3Properties
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.cloud.aws.autoconfigure.context.ContextInstanceDataAutoConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
 @EnableConfigurationProperties(S3Properties::class)
+@EnableAutoConfiguration(exclude = [ContextInstanceDataAutoConfiguration::class])
 class AwsConfig(
     private val s3Properties: S3Properties
 ) {


### PR DESCRIPTION
## 🔑 Key Changes
- ec2 metadata 를 불러오지 않도록 하였습니다.
## 🙌 To Reviewers
- 서버에 불필요한 에러 로그가 많아서 보기가 힘든 것 같아 수정하였습니다. 로컬 vm 옵션 추가했던 것도 삭제하셔도 됩니다.
- repository는 jpa repository만 사용하고 있어서 yml 파일 spring: 밑에
```
    data:
        redis:
            repositories:
                enabled: false
```
- 추가하면 spring data redis 관련 로그도 없앨 수 있습니다.