### PR TITLE
Fix: 동네생활 필요없는 fetch join 삭제

### DIFF
--- a/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/repository/NeighborPostRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/repository/NeighborPostRepository.kt
@@ -2,7 +2,6 @@ package com.wafflestudio.team03server.core.neighbor.repository
 
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.wafflestudio.team03server.core.neighbor.entity.NeighborPost
-import com.wafflestudio.team03server.core.neighbor.entity.QNeighborComment.neighborComment
 import com.wafflestudio.team03server.core.neighbor.entity.QNeighborPost.neighborPost
 import com.wafflestudio.team03server.core.user.entity.QUser.user
 import org.springframework.data.domain.Pageable
@@ -25,8 +24,6 @@ class NeighborPostSupportImpl(
             .selectFrom(neighborPost)
             .leftJoin(neighborPost.publisher, user)
             .fetchJoin()
-            .leftJoin(neighborPost.comments, neighborComment)
-            .fetchJoin()
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
             .distinct()
@@ -38,8 +35,6 @@ class NeighborPostSupportImpl(
             .selectFrom(neighborPost)
             .where(neighborPost.title.contains(neighborPostName))
             .leftJoin(neighborPost.publisher, user)
-            .fetchJoin()
-            .leftJoin(neighborPost.comments, neighborComment)
             .fetchJoin()
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())


### PR DESCRIPTION
## 🔑 Key Changes
- NeighborPost에서 batch size를 적용하는 comments에 대해 fetch join을 적용했던 부분을 삭제하였습니다.
## 🙌 To Reviewers
- 이상입니다.
