### PR TITLE
Feat: 좌표 정보 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,6 +84,10 @@ dependencies {
     kapt("com.querydsl:querydsl-apt:5.0.0:jpa")
     kapt("org.springframework.boot:spring-boot-configuration-processor")
 
+    // hibernate-spatial
+    implementation("org.hibernate:hibernate-spatial")
+    implementation("org.hibernate:hibernate-core")
+
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/SignUpRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/SignUpRequest.kt
@@ -1,8 +1,10 @@
 package com.wafflestudio.team03server.core.user.api.request
 
+import com.wafflestudio.team03server.core.user.entity.Coordinate
 import com.wafflestudio.team03server.core.user.entity.User
 import javax.validation.constraints.Email
 import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotNull
 import javax.validation.constraints.Pattern
 
 data class SignUpRequest(
@@ -23,8 +25,12 @@ data class SignUpRequest(
     val password: String?,
     @field:NotBlank(message = "주소는 필수 항목입니다.")
     val location: String?,
+    @field:NotNull(message = "좌표 정보가 없습니다.")
+    val coordinate: Coordinate?,
+    @field:NotNull(message = "이메일 인증 정보가 없습니다.")
+    val isEmailAuthed: Boolean?
 ) {
     fun toUser(): User {
-        return User(username!!, email!!, password!!, location!!)
+        return User(username!!, email!!, password!!, location!!, coordinate!!)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/SignUpRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/SignUpRequest.kt
@@ -2,6 +2,8 @@ package com.wafflestudio.team03server.core.user.api.request
 
 import com.wafflestudio.team03server.core.user.entity.Coordinate
 import com.wafflestudio.team03server.core.user.entity.User
+import org.locationtech.jts.geom.Point
+import org.locationtech.jts.io.WKTReader
 import javax.validation.constraints.Email
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
@@ -31,6 +33,14 @@ data class SignUpRequest(
     val isEmailAuthed: Boolean?
 ) {
     fun toUser(): User {
-        return User(username!!, email!!, password!!, location!!, coordinate!!)
+        val pointWKT = "POINT(${coordinate!!.lng} ${coordinate.lat})"
+        val point = WKTReader().read(pointWKT) as Point
+        return User(
+            username = username!!,
+            email = email!!,
+            password = password!!,
+            location = location!!,
+            coordinate = point
+        )
     }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/entity/Coordinate.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/entity/Coordinate.kt
@@ -1,8 +1,5 @@
 package com.wafflestudio.team03server.core.user.entity
 
-import javax.persistence.Embeddable
-
-@Embeddable
 data class Coordinate(
     var lat: Double,
     var lng: Double

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/entity/Coordinate.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/entity/Coordinate.kt
@@ -1,0 +1,9 @@
+package com.wafflestudio.team03server.core.user.entity
+
+import javax.persistence.Embeddable
+
+@Embeddable
+data class Coordinate(
+    var lat: Double,
+    var lng: Double
+)

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/entity/User.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/entity/User.kt
@@ -6,8 +6,8 @@ import com.wafflestudio.team03server.core.trade.entity.LikePost
 import com.wafflestudio.team03server.core.trade.entity.TradePost
 import javax.persistence.CascadeType
 import com.wafflestudio.team03server.core.trade.entity.Review
+import org.locationtech.jts.geom.Point
 import javax.persistence.Column
-import javax.persistence.Embedded
 import javax.persistence.Entity
 import javax.persistence.OneToMany
 import javax.persistence.Table
@@ -26,8 +26,8 @@ class User(
     var password: String,
     @NotNull
     var location: String,
-    @Embedded
-    var coordinate: Coordinate,
+
+    var coordinate: Point,
 
     @NotNull
     var temperature: Double = 36.5,

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/entity/User.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/entity/User.kt
@@ -7,6 +7,7 @@ import com.wafflestudio.team03server.core.trade.entity.TradePost
 import javax.persistence.CascadeType
 import com.wafflestudio.team03server.core.trade.entity.Review
 import javax.persistence.Column
+import javax.persistence.Embedded
 import javax.persistence.Entity
 import javax.persistence.OneToMany
 import javax.persistence.Table
@@ -25,6 +26,9 @@ class User(
     var password: String,
     @NotNull
     var location: String,
+    @Embedded
+    var coordinate: Coordinate,
+
     @NotNull
     var temperature: Double = 36.5,
     var imgUrl: String? = null,

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/service/AuthService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/service/AuthService.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.team03server.core.user.service
 
+import com.wafflestudio.team03server.common.Exception401
 import com.wafflestudio.team03server.common.Exception403
 import com.wafflestudio.team03server.common.Exception404
 import com.wafflestudio.team03server.common.Exception409
@@ -40,6 +41,9 @@ class AuthServiceImpl(
         }
         if (isDuplicateUsername(signUpRequest.username!!)) {
             throw Exception409("이미 존재하는 유저네임 입니다.")
+        }
+        if (signUpRequest.isEmailAuthed == false) {
+            throw Exception401("이메일 인증이 되지 않은 사용자 입니다.")
         }
         val user = signUpRequest.toUser()
         user.password = passwordEncoder.encode(user.password)

--- a/src/test/kotlin/com/wafflestudio/team03server/core/chat/service/ChatServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/team03server/core/chat/service/ChatServiceTest.kt
@@ -10,15 +10,14 @@ import com.wafflestudio.team03server.core.user.entity.User
 import com.wafflestudio.team03server.core.user.repository.UserRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.locationtech.jts.geom.Point
+import org.locationtech.jts.io.WKTReader
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.jdbc.EmbeddedDatabaseConnection
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 
 @SpringBootTest
-@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
 @Transactional
 internal class ChatServiceTest @Autowired constructor(
     val userRepository: UserRepository,
@@ -31,8 +30,8 @@ internal class ChatServiceTest @Autowired constructor(
     @Test
     fun 채팅_시작_성공() {
         // given
-        val user1 = User("user1", "abc1@naver.com", "1234", "관악구")
-        val user2 = User("user2", "abc2@naver.com", "1234", "관악구")
+        val user1 = createUser("user1", "abc1@naver.com", "1234", "관악구")
+        val user2 = createUser("user2", "abc2@naver.com", "1234", "관악구")
         val savedUser1 = userRepository.save(user1)
         val savedUser2 = userRepository.save(user2)
         val request = CreatePostRequest("title1", "String1", 10000)
@@ -49,8 +48,8 @@ internal class ChatServiceTest @Autowired constructor(
     @Test
     fun 채팅_시작_실패_판매자가_채팅시작() {
         // given
-        val user1 = User("user1", "abc1@naver.com", "1234", "관악구")
-        val user2 = User("user2", "abc2@naver.com", "1234", "관악구")
+        val user1 = createUser("user1", "abc1@naver.com", "1234", "관악구")
+        val user2 = createUser("user2", "abc2@naver.com", "1234", "관악구")
         val savedUser1 = userRepository.save(user1)
         val savedUser2 = userRepository.save(user2)
         val request = CreatePostRequest("title1", "String1", 10000)
@@ -63,8 +62,8 @@ internal class ChatServiceTest @Autowired constructor(
     @Test
     fun 채팅_저장_성공() {
         // given
-        val user1 = User("user1", "abc1@naver.com", "1234", "관악구")
-        val user2 = User("user2", "abc2@naver.com", "1234", "관악구")
+        val user1 = createUser("user1", "abc1@naver.com", "1234", "관악구")
+        val user2 = createUser("user2", "abc2@naver.com", "1234", "관악구")
         val savedUser1 = userRepository.save(user1)
         val savedUser2 = userRepository.save(user2)
         val request = CreatePostRequest("title1", "String1", 10000)
@@ -88,8 +87,8 @@ internal class ChatServiceTest @Autowired constructor(
     @Test
     fun 메시지_가져오기_성공() {
         // given
-        val user1 = User("user1", "abc1@naver.com", "1234", "관악구")
-        val user2 = User("user2", "abc2@naver.com", "1234", "관악구")
+        val user1 = createUser("user1", "abc1@naver.com", "1234", "관악구")
+        val user2 = createUser("user2", "abc2@naver.com", "1234", "관악구")
         val savedUser1 = userRepository.save(user1)
         val savedUser2 = userRepository.save(user2)
         val request = CreatePostRequest("title1", "String1", 10000)
@@ -110,5 +109,9 @@ internal class ChatServiceTest @Autowired constructor(
         assertThat(messages.chatHistories.size).isEqualTo(2)
         assertThat(messages.chatHistories[0].message).isEqualTo("안녕하세요!")
         assertThat(messages.chatHistories[0].senderId).isEqualTo(savedUser2.id)
+    }
+
+    private fun createUser(username: String, email: String, password: String, location: String): User {
+        return User(username, email, password, location, WKTReader().read("POINT(1.0 1.0)") as Point)
     }
 }

--- a/src/test/kotlin/com/wafflestudio/team03server/core/neighbor/service/NeighborPostServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/team03server/core/neighbor/service/NeighborPostServiceTest.kt
@@ -13,15 +13,14 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
+import org.locationtech.jts.geom.Point
+import org.locationtech.jts.io.WKTReader
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.jdbc.EmbeddedDatabaseConnection
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.domain.PageRequest
 import org.springframework.transaction.annotation.Transactional
 
 @SpringBootTest
-@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
 @Transactional
 internal class NeighborPostServiceTest @Autowired constructor(
     val userRepository: UserRepository,
@@ -161,7 +160,7 @@ internal class NeighborPostServiceTest @Autowired constructor(
     }
 
     private fun createUser(username: String, email: String, password: String, location: String = "관악구"): User {
-        val user = User(username, email, password, location)
+        val user = User(username, email, password, location, WKTReader().read("POINT(1.0 1.0)") as Point)
         userRepository.save(user)
         return user
     }

--- a/src/test/kotlin/com/wafflestudio/team03server/core/trade/service/TradePostServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/team03server/core/trade/service/TradePostServiceTest.kt
@@ -9,15 +9,14 @@ import com.wafflestudio.team03server.core.user.entity.User
 import com.wafflestudio.team03server.core.user.repository.UserRepository
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Test
+import org.locationtech.jts.geom.Point
+import org.locationtech.jts.io.WKTReader
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.jdbc.EmbeddedDatabaseConnection
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.domain.PageRequest
 import javax.transaction.Transactional
 
 @SpringBootTest
-@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
 @Transactional
 internal class TradePostServiceTest @Autowired constructor(
     val userRepository: UserRepository,
@@ -29,7 +28,7 @@ internal class TradePostServiceTest @Autowired constructor(
     @Test
     fun 글_생성_성공() {
         // given
-        val user = User("user1", "abc@naver.com", "1234", "관악구")
+        val user = createUser("user1", "abc@naver.com", "1234", "관악구")
         val savedUser = userRepository.save(user)
         val request = CreatePostRequest("title1", "String1", 10000)
 
@@ -53,7 +52,7 @@ internal class TradePostServiceTest @Autowired constructor(
     @Test
     fun 글_단건_조회_성공() {
         // given
-        val user = User("user1", "abc@naver.com", "1234", "관악구")
+        val user = createUser("user1", "abc@naver.com", "1234", "관악구")
         val savedUser = userRepository.save(user)
         val request = CreatePostRequest("title1", "String1", 10000)
         val createPost = tradePostService.createPost(savedUser.id, null, request)
@@ -75,7 +74,7 @@ internal class TradePostServiceTest @Autowired constructor(
     @Test
     fun 글_전부_조회_성공() {
         // given
-        val user = User("user1", "abc@naver.com", "1234", "관악구")
+        val user = createUser("user1", "abc@naver.com", "1234", "관악구")
         val savedUser = userRepository.save(user)
         val request = CreatePostRequest("title1", "String1", 10000)
         val request2 = CreatePostRequest("title2", "String2", 20000)
@@ -91,7 +90,7 @@ internal class TradePostServiceTest @Autowired constructor(
 
     @Test
     fun 글_페이지네이션_조회_성공() {
-        val user = User("user1", "abc@naver.com", "1234", "관악구")
+        val user = createUser("user1", "abc@naver.com", "1234", "관악구")
         val savedUser = userRepository.save(user)
         for (i in 0..99) {
             val request = CreatePostRequest("title$i", "String$i", i)
@@ -111,7 +110,7 @@ internal class TradePostServiceTest @Autowired constructor(
     @Test
     fun 글_수정_성공() {
         // given
-        val user = User("user1", "abc@naver.com", "1234", "관악구")
+        val user = createUser("user1", "abc@naver.com", "1234", "관악구")
         val savedUser = userRepository.save(user)
         val request = CreatePostRequest("title1", "desc1", 10000)
         val createdPost = tradePostService.createPost(savedUser.id, null, request)
@@ -129,7 +128,7 @@ internal class TradePostServiceTest @Autowired constructor(
     @Test
     fun 글_삭제_성공() {
         // given
-        val user = User("user1", "abc@naver.com", "1234", "관악구")
+        val user = createUser("user1", "abc@naver.com", "1234", "관악구")
         val savedUser = userRepository.save(user)
         val request = CreatePostRequest("title1", "desc1", 10000)
         val createdPost = tradePostService.createPost(savedUser.id, null, request)
@@ -145,9 +144,9 @@ internal class TradePostServiceTest @Autowired constructor(
     @Test
     fun 글_예약자_가져오기_성공() {
         // given
-        val user1 = User("user1", "abc1@naver.com", "1234", "관악구")
-        val user2 = User("user2", "abc2@naver.com", "1234", "관악구")
-        val user3 = User("user3", "abc3@naver.com", "1234", "관악구")
+        val user1 = createUser("user1", "abc1@naver.com", "1234", "관악구")
+        val user2 = createUser("user2", "abc2@naver.com", "1234", "관악구")
+        val user3 = createUser("user3", "abc3@naver.com", "1234", "관악구")
         val savedUser1 = userRepository.save(user1)
         val savedUser2 = userRepository.save(user2)
         val savedUser3 = userRepository.save(user3)
@@ -171,9 +170,9 @@ internal class TradePostServiceTest @Autowired constructor(
     @Test
     fun 글_예약자_선정하기_성공() {
         // given
-        val user1 = User("user1", "abc1@naver.com", "1234", "관악구")
-        val user2 = User("user2", "abc2@naver.com", "1234", "관악구")
-        val user3 = User("user3", "abc3@naver.com", "1234", "관악구")
+        val user1 = createUser("user1", "abc1@naver.com", "1234", "관악구")
+        val user2 = createUser("user2", "abc2@naver.com", "1234", "관악구")
+        val user3 = createUser("user3", "abc3@naver.com", "1234", "관악구")
         val savedUser1 = userRepository.save(user1)
         val savedUser2 = userRepository.save(user2)
         val savedUser3 = userRepository.save(user3)
@@ -197,9 +196,9 @@ internal class TradePostServiceTest @Autowired constructor(
     @Test
     fun 글_예약자_변경하기_성공() {
         // given
-        val user1 = User("user1", "abc1@naver.com", "1234", "관악구")
-        val user2 = User("user2", "abc2@naver.com", "1234", "관악구")
-        val user3 = User("user3", "abc3@naver.com", "1234", "관악구")
+        val user1 = createUser("user1", "abc1@naver.com", "1234", "관악구")
+        val user2 = createUser("user2", "abc2@naver.com", "1234", "관악구")
+        val user3 = createUser("user3", "abc3@naver.com", "1234", "관악구")
         val savedUser1 = userRepository.save(user1)
         val savedUser2 = userRepository.save(user2)
         val savedUser3 = userRepository.save(user3)
@@ -224,9 +223,9 @@ internal class TradePostServiceTest @Autowired constructor(
     @Test
     fun 글_거래_확정_성공() {
         // given
-        val user1 = User("user1", "abc1@naver.com", "1234", "관악구")
-        val user2 = User("user2", "abc2@naver.com", "1234", "관악구")
-        val user3 = User("user3", "abc3@naver.com", "1234", "관악구")
+        val user1 = createUser("user1", "abc1@naver.com", "1234", "관악구")
+        val user2 = createUser("user2", "abc2@naver.com", "1234", "관악구")
+        val user3 = createUser("user3", "abc3@naver.com", "1234", "관악구")
         val savedUser1 = userRepository.save(user1)
         val savedUser2 = userRepository.save(user2)
         val savedUser3 = userRepository.save(user3)
@@ -249,9 +248,9 @@ internal class TradePostServiceTest @Autowired constructor(
     @Test
     fun 글_예약_취소_성공() {
         // given
-        val user1 = User("user1", "abc1@naver.com", "1234", "관악구")
-        val user2 = User("user2", "abc2@naver.com", "1234", "관악구")
-        val user3 = User("user3", "abc3@naver.com", "1234", "관악구")
+        val user1 = createUser("user1", "abc1@naver.com", "1234", "관악구")
+        val user2 = createUser("user2", "abc2@naver.com", "1234", "관악구")
+        val user3 = createUser("user3", "abc3@naver.com", "1234", "관악구")
         val savedUser1 = userRepository.save(user1)
         val savedUser2 = userRepository.save(user2)
         val savedUser3 = userRepository.save(user3)
@@ -274,8 +273,8 @@ internal class TradePostServiceTest @Autowired constructor(
     @Test
     fun 글_찜_성공() {
         // given
-        val user1 = User("user1", "abc1@naver.com", "1234", "관악구")
-        val user2 = User("user2", "abc2@naver.com", "1234", "관악구")
+        val user1 = createUser("user1", "abc1@naver.com", "1234", "관악구")
+        val user2 = createUser("user2", "abc2@naver.com", "1234", "관악구")
         val savedUser1 = userRepository.save(user1)
         val savedUser2 = userRepository.save(user2)
         val request = CreatePostRequest("title1", "String1", 10000)
@@ -296,8 +295,8 @@ internal class TradePostServiceTest @Autowired constructor(
     @Test
     fun 글_찜_취소_성공() {
         // given
-        val user1 = User("user1", "abc1@naver.com", "1234", "관악구")
-        val user2 = User("user2", "abc2@naver.com", "1234", "관악구")
+        val user1 = createUser("user1", "abc1@naver.com", "1234", "관악구")
+        val user2 = createUser("user2", "abc2@naver.com", "1234", "관악구")
         val savedUser1 = userRepository.save(user1)
         val savedUser2 = userRepository.save(user2)
         val request = CreatePostRequest("title1", "String1", 10000)
@@ -318,11 +317,11 @@ internal class TradePostServiceTest @Autowired constructor(
     fun 인기_탑3_글_조회_성공() {
         // given
         // 유저 생성
-        val user1 = User("user1", "abc1@naver.com", "1234", "관악구")
-        val user2 = User("user2", "abc2@naver.com", "1234", "관악구")
-        val user3 = User("user3", "abc3@naver.com", "1234", "관악구")
-        val user4 = User("user4", "abc4@naver.com", "1234", "관악구")
-        val user5 = User("user5", "abc5@naver.com", "1234", "관악구")
+        val user1 = createUser("user1", "abc1@naver.com", "1234", "관악구")
+        val user2 = createUser("user2", "abc2@naver.com", "1234", "관악구")
+        val user3 = createUser("user3", "abc3@naver.com", "1234", "관악구")
+        val user4 = createUser("user4", "abc4@naver.com", "1234", "관악구")
+        val user5 = createUser("user5", "abc5@naver.com", "1234", "관악구")
         val savedUser1 = userRepository.save(user1)
         val savedUser2 = userRepository.save(user2)
         val savedUser3 = userRepository.save(user3)
@@ -366,5 +365,9 @@ internal class TradePostServiceTest @Autowired constructor(
         assertThat(topThreePosts.posts[0].postId).isEqualTo(post3.postId)
         assertThat(topThreePosts.posts[0].title).isEqualTo(post3.title)
         assertThat(topThreePosts.posts[0].likeCount).isGreaterThan(topThreePosts.posts[1].likeCount)
+    }
+
+    private fun createUser(username: String, email: String, password: String, location: String): User {
+        return User(username, email, password, location, WKTReader().read("POINT(1.0 1.0)") as Point)
     }
 }

--- a/src/test/kotlin/com/wafflestudio/team03server/core/user/service/UserServiceImplTest.kt
+++ b/src/test/kotlin/com/wafflestudio/team03server/core/user/service/UserServiceImplTest.kt
@@ -16,16 +16,15 @@ import com.wafflestudio.team03server.core.user.repository.UserRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import org.locationtech.jts.geom.Point
+import org.locationtech.jts.io.WKTReader
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.jdbc.EmbeddedDatabaseConnection
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 
-@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
 @Transactional
 @SpringBootTest
 internal class UserServiceImplTest @Autowired constructor(
@@ -39,7 +38,7 @@ internal class UserServiceImplTest @Autowired constructor(
     @Test
     fun 유저_정보_조회_성공() {
         //given
-        val user = User("user1", "a@naver.com", "1234", "송도동")
+        val user = createUser("user1", "a@naver.com", "1234", "송도동")
         val savedUser = userRepository.save(user)
         //when
         val userResponse = userService.getProfile(savedUser.id)
@@ -60,7 +59,7 @@ internal class UserServiceImplTest @Autowired constructor(
 
         //when
         val exception = assertThrows(Exception404::class.java) {
-            userService.getProfile(1)
+            userService.getProfile(12108)
         }
         //then
         assertThat(exception.message).isEqualTo("사용자를 찾을 수 없습니다.")
@@ -69,7 +68,7 @@ internal class UserServiceImplTest @Autowired constructor(
     @Test
     fun 유저네임_수정_성공() {
         //given
-        val user = User("user1", "a@naver.com", "1234", "송도동")
+        val user = createUser("user1", "a@naver.com", "1234", "송도동")
         val savedUser = userRepository.save(user)
         //when
         userService.editUsername(savedUser.id, EditUsernameRequest("Edited"))
@@ -81,8 +80,8 @@ internal class UserServiceImplTest @Autowired constructor(
     @Test
     fun 유저네임_수정_실패() {
         //given
-        val user1 = User("user1", "a@naver.com", "1234", "송도동")
-        val user2 = User("user2", "b@naver.com", "1234", "송도동")
+        val user1 = createUser("user1", "a@naver.com", "1234", "송도동")
+        val user2 = createUser("user2", "b@naver.com", "1234", "송도동")
         val savedUser1 = userRepository.save(user1)
         val savedUser2 = userRepository.save(user2)
         //when
@@ -96,7 +95,7 @@ internal class UserServiceImplTest @Autowired constructor(
     @Test
     fun 주소_수정_성공() {
         //given
-        val user = User("user1", "a@naver.com", "1234", "송도동")
+        val user = createUser("user1", "a@naver.com", "1234", "송도동")
         val savedUser = userRepository.save(user)
         //when
         userService.editLocation(savedUser.id, EditLocationRequest("Edited"))
@@ -108,7 +107,7 @@ internal class UserServiceImplTest @Autowired constructor(
     @Test
     fun 비밀번호_수정_성공() {
         //given
-        val user = User("user1", "a@naver.com", "1234", "송도동")
+        val user = createUser("user1", "a@naver.com", "1234", "송도동")
         user.password = passwordEncoder.encode(user.password)
         val savedUser = userRepository.save(user)
         //when
@@ -124,7 +123,7 @@ internal class UserServiceImplTest @Autowired constructor(
     @Test
     fun 비밀번호_수정_실패_비밀번호_틀림() {
         //given
-        val user = User("user1", "a@naver.com", "1234", "송도동")
+        val user = createUser("user1", "a@naver.com", "1234", "송도동")
         user.password = passwordEncoder.encode(user.password)
         val savedUser = userRepository.save(user)
         //when
@@ -141,7 +140,7 @@ internal class UserServiceImplTest @Autowired constructor(
     @Test
     fun 비밀번호_수정_실패_새비밀번호_불일치() {
         //given
-        val user = User("user1", "a@naver.com", "1234", "송도동")
+        val user = createUser("user1", "a@naver.com", "1234", "송도동")
         user.password = passwordEncoder.encode(user.password)
         val savedUser = userRepository.save(user)
         //when
@@ -158,9 +157,9 @@ internal class UserServiceImplTest @Autowired constructor(
     @Test
     fun 글_구매_내역_조회_성공() {
         // given
-        val user1 = User("user1", "abc1@naver.com", "1234", "관악구")
-        val user2 = User("user2", "abc2@naver.com", "1234", "관악구")
-        val user3 = User("user3", "abc3@naver.com", "1234", "관악구")
+        val user1 = createUser("user1", "abc1@naver.com", "1234", "관악구")
+        val user2 = createUser("user2", "abc2@naver.com", "1234", "관악구")
+        val user3 = createUser("user3", "abc3@naver.com", "1234", "관악구")
         val savedUser1 = userRepository.save(user1)
         val savedUser2 = userRepository.save(user2)
         val savedUser3 = userRepository.save(user3)
@@ -194,8 +193,8 @@ internal class UserServiceImplTest @Autowired constructor(
     @Test
     fun 글_판매_내역_조회_성공() {
         // given
-        val user1 = User("user1", "abc1@naver.com", "1234", "관악구")
-        val user2 = User("user2", "abc2@naver.com", "1234", "관악구")
+        val user1 = createUser("user1", "abc1@naver.com", "1234", "관악구")
+        val user2 = createUser("user2", "abc2@naver.com", "1234", "관악구")
         val savedUser1 = userRepository.save(user1)
         val savedUser2 = userRepository.save(user2)
 
@@ -217,9 +216,9 @@ internal class UserServiceImplTest @Autowired constructor(
     @Test
     fun 내_채팅목록_내역_조회_성공() {
         // given
-        val user1 = User("user1", "abc1@naver.com", "1234", "관악구")
-        val user2 = User("user2", "abc2@naver.com", "1234", "관악구")
-        val user3 = User("user3", "abc3@naver.com", "1234", "관악구")
+        val user1 = createUser("user1", "abc1@naver.com", "1234", "관악구")
+        val user2 = createUser("user2", "abc2@naver.com", "1234", "관악구")
+        val user3 = createUser("user3", "abc3@naver.com", "1234", "관악구")
         val savedUser1 = userRepository.save(user1)
         val savedUser2 = userRepository.save(user2)
         val savedUser3 = userRepository.save(user3)
@@ -246,5 +245,9 @@ internal class UserServiceImplTest @Autowired constructor(
         assertThat(mychats.chats[0].lastChat.message).isEqualTo(chatMessage2.message)
         assertThat(mychats.chats[1].roomUUID).isEqualTo(chat2.roomUUID)
         assertThat(mychats.chats[1].lastChat.message).isEqualTo(chatMessage3.message)
+    }
+
+    private fun createUser(username: String, email: String, password: String, location: String): User {
+        return User(username, email, password, location, WKTReader().read("POINT(1.0 1.0)") as Point)
     }
 }


### PR DESCRIPTION
## 🔑 Key Changes
- 유저 엔티티에 좌표 정보 추가
- 엔티티 변경하면서 테스트 코드 깨지는 것 임시 수정
- 서버단에서 이메일 인증 한번 더 체크
## :computer: Test Result (기능 구현인 경우)
- 로컬에서 테스트 완료하였습니다.
## 🙌 To Reviewers
- 엔티티에 좌표 정보 추가하면서 테스트 H2 db에서 SQL 에러가 나서 로컬에서도 mysql로 테스트 해주셔야 할것 같습니다ㅜ
- yml 파일에 아래 항목 추가하였습니다
```
spring:
    jpa:
        database: mysql
        database-platform: org.hibernate.spatial.dialect.mysql.MySQL56InnoDBSpatialDialect
```
- 좌표 기반 검색 네이티브 쿼리도 테스트 해봤는데 jpaRepository 밑에 아래 코드 추가하고 변형해서 쓰시면 될것 같습니다.
- 아래 코드는 tradepost 검색 테스트 예시입니다.
```
@Query(
        value = "SELECT p.*, ST_Distance_Sphere(u.coordinate, :point) as distance FROM trade_post p " +
            "JOIN users u ON p.seller_id = u.id HAVING distance <= :distance ORDER BY distance LIMIT :limit",
        nativeQuery = true
    )
    fun findPosts(
        @Param("point") point: Point,
        @Param("distance") distance: Double,
        @Param("limit") limit: Int
    ): List<TradePost>
```

