### PR TITLE
Feat: 동네생활 내가 쓴 글, 좋아요한 글 모아보기

### DIFF
--- a/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/api/NeighborController.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/api/NeighborController.kt
@@ -25,7 +25,7 @@ class NeighborController(
         @RequestParam("name") neighborPostName: String?,
         @RequestParam("page", required = false, defaultValue = "1") page: Int?
     ): List<NeighborPostResponse> {
-        val pageable = PageRequest.of(page!! - 1, 50)
+        val pageable = PageRequest.of(page!! - 1, 10)
         return neighborPostService.getAllNeighborPosts(userId, neighborPostName, pageable)
     }
 

--- a/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/api/NeighborController.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/api/NeighborController.kt
@@ -71,7 +71,7 @@ class NeighborController(
     fun likeNeighborPost(
         @UserContext userId: Long,
         @PathVariable("post-id") postId: Long
-    ) {
+    ): NeighborPostResponse {
         return neighborPostService.likeOrUnlikeNeighborPost(userId, postId)
     }
 

--- a/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/repository/NeighborPostRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/repository/NeighborPostRepository.kt
@@ -13,6 +13,7 @@ interface NeighborPostRepository : JpaRepository<NeighborPost, Long>, NeighborPo
 interface NeighborPostSupport {
     fun findAllByQuerydsl(pageable: Pageable): List<NeighborPost>
     fun findAllByTitleContains(neighborPostName: String, pageable: Pageable): List<NeighborPost>
+    fun findAllByPublisherId(publisherId: Long): List<NeighborPost>
 }
 
 @Component
@@ -38,6 +39,16 @@ class NeighborPostSupportImpl(
             .fetchJoin()
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
+            .distinct()
+            .fetch()
+    }
+
+    override fun findAllByPublisherId(publisherId: Long): List<NeighborPost> {
+        return queryFactory
+            .selectFrom(neighborPost)
+            .leftJoin(neighborPost.publisher, user)
+            .fetchJoin()
+            .where(neighborPost.publisher.id.eq(publisherId))
             .distinct()
             .fetch()
     }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/repository/NeighborPostRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/repository/NeighborPostRepository.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.team03server.core.neighbor.repository
 
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.wafflestudio.team03server.core.neighbor.entity.NeighborPost
+import com.wafflestudio.team03server.core.neighbor.entity.QNeighborLike.neighborLike
 import com.wafflestudio.team03server.core.neighbor.entity.QNeighborPost.neighborPost
 import com.wafflestudio.team03server.core.user.entity.QUser.user
 import org.springframework.data.domain.Pageable
@@ -14,6 +15,7 @@ interface NeighborPostSupport {
     fun findAllByQuerydsl(pageable: Pageable): List<NeighborPost>
     fun findAllByTitleContains(neighborPostName: String, pageable: Pageable): List<NeighborPost>
     fun findAllByPublisherId(publisherId: Long): List<NeighborPost>
+    fun findAllByLikerId(likerId: Long): List<NeighborPost>
 }
 
 @Component
@@ -49,6 +51,18 @@ class NeighborPostSupportImpl(
             .leftJoin(neighborPost.publisher, user)
             .fetchJoin()
             .where(neighborPost.publisher.id.eq(publisherId))
+            .distinct()
+            .fetch()
+    }
+
+    override fun findAllByLikerId(likerId: Long): List<NeighborPost> {
+        return queryFactory
+            .selectFrom(neighborPost)
+            .leftJoin(neighborPost.publisher, user)
+            .fetchJoin()
+            .leftJoin(neighborLike)
+            .on(neighborPost.id.eq(neighborLike.likedPost.id))
+            .where(neighborLike.liker.id.eq(likerId))
             .distinct()
             .fetch()
     }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/service/NeighborPostService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/service/NeighborPostService.kt
@@ -28,7 +28,7 @@ interface NeighborPostService {
     ): NeighborPostResponse
 
     fun deleteNeighborPost(userId: Long, postId: Long)
-    fun likeOrUnlikeNeighborPost(userId: Long, postId: Long)
+    fun likeOrUnlikeNeighborPost(userId: Long, postId: Long): NeighborPostResponse
 }
 
 @Service
@@ -110,7 +110,7 @@ class NeighborPostServiceImpl(
         if (post.publisher == user) throw Exception400("본인의 글에는 좋아요를 누를 수 없습니다.")
     }
 
-    override fun likeOrUnlikeNeighborPost(userId: Long, postId: Long) {
+    override fun likeOrUnlikeNeighborPost(userId: Long, postId: Long): NeighborPostResponse {
         val readUser = getUserById(userId)
         val readPost = getNeighborPostById(postId)
         checkPublisherEqualsLiker(readUser, readPost)
@@ -123,5 +123,6 @@ class NeighborPostServiceImpl(
         } else {
             readLike.changeStatus()
         }
+        return NeighborPostResponse.of(readPost, userId)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/UserController.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/UserController.kt
@@ -106,4 +106,10 @@ class UserController(
     fun getMyNeighborhoodPosts(@UserContext userId: Long): List<NeighborPostResponse> {
         return userService.getMyNeighborhoodPosts(userId)
     }
+
+    @Authenticated
+    @GetMapping("/like-neighborhood")
+    fun getLikeNeighborhoodPosts(@UserContext userId: Long): List<NeighborPostResponse> {
+        return userService.getLikeNeighborhoodPosts(userId)
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/UserController.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/UserController.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.team03server.core.user.api
 import com.wafflestudio.team03server.common.Authenticated
 import com.wafflestudio.team03server.common.Exception400
 import com.wafflestudio.team03server.common.UserContext
+import com.wafflestudio.team03server.core.neighbor.api.response.NeighborPostResponse
 import com.wafflestudio.team03server.core.trade.api.response.PostListResponse
 import com.wafflestudio.team03server.core.user.api.request.EditLocationRequest
 import com.wafflestudio.team03server.core.user.api.request.EditPasswordRequest
@@ -98,5 +99,11 @@ class UserController(
     @GetMapping("/chats")
     fun getMyChats(@UserContext userId: Long): MyChatsResponse {
         return userService.getMyChats(userId)
+    }
+
+    @Authenticated
+    @GetMapping("/neighborhood-post")
+    fun getMyNeighborhoodPosts(@UserContext userId: Long): List<NeighborPostResponse> {
+        return userService.getMyNeighborhoodPosts(userId)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/service/UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/service/UserService.kt
@@ -2,6 +2,8 @@ package com.wafflestudio.team03server.core.user.service
 
 import com.wafflestudio.team03server.common.*
 import com.wafflestudio.team03server.core.chat.repository.ChatRoomRepository
+import com.wafflestudio.team03server.core.neighbor.api.response.NeighborPostResponse
+import com.wafflestudio.team03server.core.neighbor.repository.NeighborPostRepository
 import com.wafflestudio.team03server.core.trade.api.response.PostListResponse
 import com.wafflestudio.team03server.core.trade.entity.TradeStatus
 import com.wafflestudio.team03server.core.trade.repository.LikePostRepository
@@ -29,6 +31,7 @@ interface UserService {
     fun getSellTradePosts(userId: Long, sellerId: Long): PostListResponse
     fun getMyChats(userId: Long): MyChatsResponse
     fun getLikeTradePosts(userId: Long): PostListResponse
+    fun getMyNeighborhoodPosts(userId: Long): List<NeighborPostResponse>
 }
 
 @Service
@@ -41,6 +44,7 @@ class UserServiceImpl(
     private val tradePostRepository: TradePostRepository,
     private val chatRoomRepository: ChatRoomRepository,
     private val likePostRepository: LikePostRepository,
+    private val neighborPostRepository: NeighborPostRepository,
 ) : UserService {
     override fun getProfile(userId: Long): UserResponse {
         val user = userRepository.findByIdOrNull(userId) ?: throw Exception404("사용자를 찾을 수 없습니다.")
@@ -110,5 +114,10 @@ class UserServiceImpl(
         val user = userRepository.findByIdOrNull(userId) ?: throw Exception404("사용자를 찾을 수 없습니다.")
         val likedPosts = likePostRepository.findLikePostsWithUserAndPostByUserId(user).map { it.likedPost }
         return PostListResponse.of(user, likedPosts)
+    }
+
+    override fun getMyNeighborhoodPosts(userId: Long): List<NeighborPostResponse> {
+        val user = userRepository.findByIdOrNull(userId) ?: throw Exception404("사용자를 찾을 수 없습니다.")
+        return neighborPostRepository.findAllByPublisherId(userId).map { NeighborPostResponse.of(it, userId) }
     }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/service/UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/service/UserService.kt
@@ -32,6 +32,7 @@ interface UserService {
     fun getMyChats(userId: Long): MyChatsResponse
     fun getLikeTradePosts(userId: Long): PostListResponse
     fun getMyNeighborhoodPosts(userId: Long): List<NeighborPostResponse>
+    fun getLikeNeighborhoodPosts(userId: Long): List<NeighborPostResponse>
 }
 
 @Service
@@ -119,5 +120,10 @@ class UserServiceImpl(
     override fun getMyNeighborhoodPosts(userId: Long): List<NeighborPostResponse> {
         val user = userRepository.findByIdOrNull(userId) ?: throw Exception404("사용자를 찾을 수 없습니다.")
         return neighborPostRepository.findAllByPublisherId(userId).map { NeighborPostResponse.of(it, userId) }
+    }
+
+    override fun getLikeNeighborhoodPosts(userId: Long): List<NeighborPostResponse> {
+        val user = userRepository.findByIdOrNull(userId) ?: throw Exception404("사용자를 찾을 수 없습니다.")
+        return neighborPostRepository.findAllByLikerId(userId).map { NeighborPostResponse.of(it, userId) }
     }
 }


### PR DESCRIPTION
## 🔑 Key Changes
- 동네생활과 관련하여 내가 쓴 글과 좋아요한 글 모아보는 기능을 추가했습니다.
## :computer: Test Result (기능 구현인 경우)
- 로컬에서 확인했습니다.
## 🙌 To Reviewers
- 내가 쓴 글과 좋아요한 글이 마이페이지에서 보는 글이라서 users 하위에 넣어놓았습니다.
- 추가적으로 동네생활 좋아요 응답을 보낼 때 좋아요/좋아요취소를 누른 글을 response로 넘기기로 해서 그 부분도 약간 수정이 들어갔습니다.
