### PR TITLE
Feat: 비밀번호 재설정 기능 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/AuthController.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/AuthController.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.team03server.core.user.api
 
 import com.wafflestudio.team03server.core.user.api.request.LoginRequest
 import com.wafflestudio.team03server.core.user.api.request.RefreshRequest
+import com.wafflestudio.team03server.core.user.api.request.ResetPasswordRequest
 import com.wafflestudio.team03server.core.user.api.request.SignUpRequest
 import com.wafflestudio.team03server.core.user.api.response.LoginResponse
 import com.wafflestudio.team03server.core.user.service.AuthService
@@ -62,5 +63,12 @@ class AuthController(
     fun refresh(@RequestBody @Valid refreshRequest: RefreshRequest): ResponseEntity<AuthToken> {
         val authToken = authService.refresh(refreshRequest.refreshToken!!)
         return ResponseEntity(authToken, HttpStatus.OK)
+    }
+
+    // 비밀번호 재설정
+    @PatchMapping("/resetPassword")
+    fun resetPassword(@RequestBody @Valid resetPasswordRequest: ResetPasswordRequest): ResponseEntity<Any> {
+        authService.resetPassword(resetPasswordRequest)
+        return ResponseEntity(HttpStatus.OK)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/ResetPasswordRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/user/api/request/ResetPasswordRequest.kt
@@ -1,0 +1,16 @@
+package com.wafflestudio.team03server.core.user.api.request
+
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Pattern
+
+data class ResetPasswordRequest(
+    val email: String,
+    val isEmailAuthed: Boolean,
+    @field:Pattern(
+        regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@\$!%*#?&])[A-Za-z\\d@\$!%*#?&]{8,20}\$",
+        message = "비밀번호는 특수문자, 영문자, 숫자 포함 8~20자 여야 합니다"
+    )
+    @field:NotBlank(message = "비밀번호는 필수 항목입니다.")
+    val newPassword: String?,
+    val newPasswordConfirm: String
+)

--- a/src/test/kotlin/com/wafflestudio/team03server/core/user/service/AuthServiceImplTest.kt
+++ b/src/test/kotlin/com/wafflestudio/team03server/core/user/service/AuthServiceImplTest.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.team03server.core.user.service
 import com.wafflestudio.team03server.common.Exception403
 import com.wafflestudio.team03server.common.Exception404
 import com.wafflestudio.team03server.common.Exception409
+import com.wafflestudio.team03server.core.user.api.request.ResetPasswordRequest
 import com.wafflestudio.team03server.core.user.api.request.SignUpRequest
 import com.wafflestudio.team03server.core.user.entity.Coordinate
 import com.wafflestudio.team03server.core.user.entity.User
@@ -127,6 +128,20 @@ internal class AuthServiceImplTest @Autowired constructor(
         }
         //then
         assertThat(exception.message).isEqualTo("이메일 또는 비밀번호가 잘못되었습니다.")
+    }
+
+    @Test
+    fun 비밀번호_재설정_성공() {
+        // given
+        val user = createUser("user1", "b@naver.com", "1234", "송도동")
+        val savedUser = userRepository.save(user)
+        val resetPasswordRequest = ResetPasswordRequest("b@naver.com", true, "abcd1234!", "abcd1234!")
+
+        // when
+        authService.resetPassword(resetPasswordRequest)
+
+        // then
+        assertThat(passwordEncoder.matches("abcd1234!", savedUser.password))
     }
 
     private fun createSignUpRequest(


### PR DESCRIPTION
## 🔑 Key Changes
- 비밀번호 재설정 api를 추가했습니다.
## :computer: Test Result (기능 구현인 경우)
- 로컬에서 잘 작동합니다.
## 🙌 To Reviewers
- 비밀번호 재설정 전 이메일 인증하는 부분은 기존의 이메일 인증 api를 활용하면 되는 것 같아서 인증 이후 로그인 없이도 비밀번호를 재설정하는 부분만 구현했습니다!
