### PR TITLE
Fix: 좋아요한 글 목록에서 좋아요 취소된 글 안보이도록 수정

### DIFF
--- a/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/repository/NeighborPostRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/neighbor/repository/NeighborPostRepository.kt
@@ -61,7 +61,10 @@ class NeighborPostSupportImpl(
             .fetchJoin()
             .leftJoin(neighborLike)
             .on(neighborPost.id.eq(neighborLike.likedPost.id))
-            .where(neighborLike.liker.id.eq(likerId))
+            .where(
+                neighborLike.liker.id.eq(likerId),
+                neighborLike.deleteStatus.eq(false)
+            )
             .orderBy(neighborPost.createdAt.desc())
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())


### PR DESCRIPTION
## 🔑 Key Changes
- 좋아요한 글에서 deleteStatus가 false인 글만 보이도록 수정했습니다.
## :computer: Test Result (기능 구현인 경우)
- 로컬에서 테스트 완료했습니다.
## 🙌 To Reviewers
- 마지막까지 화이팅! (민폐가 되지 않게 최선을 다하겠습니다...)
