### PR TITLE
Fix: 서버 컨테이너 포트 변경

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -66,4 +66,4 @@ jobs:
           sudo docker rm prod-server
           sudo docker image rm ${{ secrets.DOCKER_REPO }}
           sudo docker pull ${{ secrets.DOCKER_REPO }}
-          sudo docker run -d -p 80:8080 --name prod-server ${{ secrets.DOCKER_REPO }}
+          sudo docker run -d -p 81:8080 --name prod-server ${{ secrets.DOCKER_REPO }}

--- a/.github/workflows/gradleTest.yml
+++ b/.github/workflows/gradleTest.yml
@@ -66,4 +66,4 @@ jobs:
           sudo docker rm test-server
           sudo docker image rm ${{ secrets.DOCKER_TEST_REPO }}
           sudo docker pull ${{ secrets.DOCKER_TEST_REPO }}
-          sudo docker run -d -p 81:8080 --name test-server ${{ secrets.DOCKER_TEST_REPO }}
+          sudo docker run -d -p 82:8080 --name test-server ${{ secrets.DOCKER_TEST_REPO }}


### PR DESCRIPTION
## 🔑 Key Changes
- 80번 포트에 nginx 컨테이너 띄우면서 CI 에서 메인 서버 컨테이너 포트를 81번으로 띄우도록 변경하였습니다.
- 테스트 서버 포트는 82번으로 변경하였습니다
## 🙌 To Reviewers
- https 설정하다 보니까 언젠지 모르겠는데 도커 test-server 컨테이너가 내려가 있었음
- 그래서 지금 dev로 푸시하면 CI 가 작동 안하는것 같은데 API 개발은 거의 끝난 것 같아서 test-server 새로 띄우진 않을게