### PR TITLE
Fix: 후기 삭제 생성 반복하여 온도 무한정 올라가던 버그 수정

### DIFF
--- a/src/main/kotlin/com/wafflestudio/team03server/core/trade/repository/ReviewRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/trade/repository/ReviewRepository.kt
@@ -3,4 +3,6 @@ package com.wafflestudio.team03server.core.trade.repository
 import com.wafflestudio.team03server.core.trade.entity.Review
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface ReviewRepository : JpaRepository<Review, Long>
+interface ReviewRepository : JpaRepository<Review, Long> {
+    fun findByTradePostIdAndReviewerId(tradePostId: Long, reviewerId: Long): Review?
+}

--- a/src/main/kotlin/com/wafflestudio/team03server/core/trade/service/ReviewService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/trade/service/ReviewService.kt
@@ -30,6 +30,7 @@ class ReviewService(
         val reviewer = getUserById(reviewerId)
         checkTradeFinished(post)
         checkReviewerBuyerOrSeller(reviewer, post)
+        checkDuplicateReview(postId, reviewerId)
         val reviewee = if (reviewer == post.seller) post.buyer else post.seller
         val (score, content) = createReviewRequest
         val review = Review.create(post, reviewer, reviewee!!, score!!, content)
@@ -81,6 +82,12 @@ class ReviewService(
     private fun checkReviewerBuyerOrSeller(reviewer: User, post: TradePost) {
         if (reviewer != post.buyer && reviewer != post.seller) {
             throw Exception403("거래 당사자만 후기를 작성할 수 있습니다.")
+        }
+    }
+
+    private fun checkDuplicateReview(tradePostId: Long, reviewerId: Long) {
+        if (reviewRepository.findByTradePostIdAndReviewerId(tradePostId, reviewerId) != null) {
+            throw Exception403("이미 작성한 후기가 있습니다.")
         }
     }
 

--- a/src/main/kotlin/com/wafflestudio/team03server/core/trade/service/ReviewService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/trade/service/ReviewService.kt
@@ -51,6 +51,7 @@ class ReviewService(
         val review = getReviewById(reviewId)
         val reviewer = getUserById(userId)
         checkReviewer(reviewer, review)
+        review.reviewee.temperature -= review.score
         reviewRepository.delete(review)
     }
 

--- a/src/main/kotlin/com/wafflestudio/team03server/core/trade/service/ReviewService.kt
+++ b/src/main/kotlin/com/wafflestudio/team03server/core/trade/service/ReviewService.kt
@@ -34,6 +34,11 @@ class ReviewService(
         val (score, content) = createReviewRequest
         val review = Review.create(post, reviewer, reviewee!!, score!!, content)
         reviewee.temperature = round((reviewee.temperature + score) * 10) / 10
+        if (reviewee.temperature < 0) {
+            reviewee.temperature = 0.0
+        } else if (reviewee.temperature > 100) {
+            reviewee.temperature = 100.0
+        }
         reviewRepository.save(review)
     }
 
@@ -51,7 +56,7 @@ class ReviewService(
         val review = getReviewById(reviewId)
         val reviewer = getUserById(userId)
         checkReviewer(reviewer, review)
-        review.reviewee.temperature -= review.score
+        review.reviewee.temperature = round((review.reviewee.temperature - review.score) * 10) / 10
         reviewRepository.delete(review)
     }
 


### PR DESCRIPTION
## 🔑 Key Changes
- 후기 삭제시 온도를 후기 생성 전으로 복구 하였습니다.
- 최대 최소 온도를 설정하였습니다.
- 후기 중복 작성이 불가능하게 하였습니다.
## :computer: Test Result (기능 구현인 경우)
- 테스트는 아직입니다.
## 🙌 To Reviewers
- 버그 수정은 해야지😢  